### PR TITLE
fix(desktop): reqwest 加 no_proxy() 强制直连，修复挂梯子时登录转圈/验证码误判

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -222,6 +222,7 @@ fn percent_decode(s: &str) -> Option<String> {
 async fn download_file(url: String, cookies: String, filename: String) -> Result<String, String> {
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::limited(10))
+        .no_proxy()
         .user_agent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36")
         .build()
         .map_err(|e| e.to_string())?;
@@ -285,6 +286,7 @@ struct BinaryOut {
 async fn fetch_binary(url: String, cookies: String) -> Result<BinaryOut, String> {
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::limited(10))
+        .no_proxy()
         .user_agent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36")
         .build()
         .map_err(|e| e.to_string())?;
@@ -335,6 +337,11 @@ async fn http_request(input: HttpInput) -> Result<HttpOutput, String> {
 
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
+        // 全部目标域均为 *.tsinghua.edu.cn：强制直连，绕过系统代理/梯子。
+        // reqwest 0.12 默认读 Windows 系统代理——Clash 等开启系统代理后登录链
+        // 被路由到代理节点：id.tsinghua 风控慢响应（转圈）、验证码与会话出口
+        // IP 不一致（对码判错）、响应被代理拦截（重发后反而直接进入）。
+        .no_proxy()
         .timeout(Duration::from_millis(input.timeout_ms.unwrap_or(20000)))
         .build()
         .map_err(|e| e.to_string())?;


### PR DESCRIPTION
Fixes #1

## 问题
开着 Clash 等系统代理登录时（详见 #1）：
1. 登录无限转圈；
2. 验证码输入正确仍报错；
3. 点「重新发送」后不经验证直接进入。

## 根因
reqwest 0.12 默认读取 Windows 系统代理，登录链（`id.tsinghua.edu.cn`）被路由到代理的海外节点：风控慢响应导致转圈；获取与提交验证码可能经不同代理出口，服务端 IP 比对不一致导致对码判错；服务端已放行但响应被代理拦截，重发时检查到登录态直接放行。

## 修复
App 全部目标域均为 `*.tsinghua.edu.cn`，本就不应经代理。为 `lib.rs` 三处 `reqwest::Client::builder()`（`download_file` / `fetch_binary` / `http_request`）统一加 `.no_proxy()` 强制直连：

- ✅ `cargo check` 通过
- ✅ 实测：Clash 系统代理开启状态下登录、验证码、进主界面全流程正常

## 影响
无直连场景的副作用——App 不访问任何非清华域名，代理对它只有干扰没有作用。
