### PR TITLE
feat(washer): 楼栋选择下拉增加搜索过滤

### DIFF
--- a/apps/desktop/src/pages/info/WasherTab.tsx
+++ b/apps/desktop/src/pages/info/WasherTab.tsx
@@ -41,6 +41,9 @@ export function WasherTab() {
   const [dState, setDState] = useState<DeviceState>("idle");
   const [dError, setDError] = useState<string | null>(null);
 
+  const [ddOpen, setDdOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
   const loadGroups = useCallback(async () => {
     if (status !== "ready") return;
     setGState("loading");
@@ -87,32 +90,73 @@ export function WasherTab() {
       {gState === "loading" && !groups ? (
         <SkeletonRows rows={3} />
       ) : (
-        <select
-          className="input filter-select"
-          value={sel ? `${sel.hlsh ? "h" : "j"}-${sel.id}` : ""}
-          onChange={(e) => {
-            const v = e.target.value;
-            if (!v) return;
-            const [kind, id] = [v[0], v.slice(2)]; /* value 形如 h-{id}，跳过前缀两字符 */
-            const b = (groups ?? [])
-              .flatMap((g) => g.buildings)
-              .find((x) => String(x.id) === id && (kind === "h" ? !!x.hlsh : !x.hlsh));
-            if (b) void loadDevices(b);
-          }}
-        >
-          <option value="">选择楼栋…</option>
-          {(groups ?? [])
+        (() => {
+          /* 楼栋搜索：按楼栋名/分组名模糊匹配（大小写不敏感），命中分组名时展开整组 */
+          const q = query.trim().toLowerCase();
+          const matched = (groups ?? [])
             .filter((g) => g.buildings.length > 0)
-            .map((g) => (
-              <optgroup key={g.name} label={g.name}>
-                {g.buildings.map((b) => (
-                  <option key={`${g.name}-${b.id}`} value={`${b.hlsh ? "h" : "j"}-${b.id}`}>
-                    {b.name}
-                  </option>
-                ))}
-              </optgroup>
-            ))}
-        </select>
+            .map((g) => ({
+              ...g,
+              buildings: q
+                ? g.buildings.filter(
+                    (b) =>
+                      b.name.toLowerCase().includes(q) || g.name.toLowerCase().includes(q),
+                  )
+                : g.buildings,
+            }))
+            .filter((g) => g.buildings.length > 0);
+          const pick = (b: WasherBuilding) => {
+            setDdOpen(false);
+            setQuery("");
+            void loadDevices(b);
+          };
+          return (
+            <div className="filter-dd">
+              <button
+                type="button"
+                className="input filter-dd-btn"
+                onClick={() => setDdOpen((o) => !o)}
+              >
+                <span>{sel ? sel.name : "选择楼栋…"}</span>
+                <span style={{ opacity: 0.55 }}>▾</span>
+              </button>
+              {ddOpen ? (
+                <>
+                  <div className="seg-menu-backdrop" onClick={() => setDdOpen(false)} />
+                  <div className="filter-dd-panel">
+                    <input
+                      className="input washer-dd-search"
+                      placeholder="搜索楼栋…"
+                      value={query}
+                      onChange={(e) => setQuery(e.target.value)}
+                    />
+                    <div className="washer-dd-list">
+                      {matched.length === 0 ? (
+                        <div className="washer-dd-empty">无匹配楼栋</div>
+                      ) : (
+                        matched.map((g) => (
+                          <div key={g.name}>
+                            <div className="washer-dd-group">{g.name}</div>
+                            {g.buildings.map((b) => (
+                              <button
+                                type="button"
+                                key={`${g.name}-${b.id}`}
+                                className={`filter-dd-opt washer-dd-opt${sel && b.id === sel.id && !!b.hlsh === !!sel.hlsh ? " is-sel" : ""}`}
+                                onClick={() => pick(b)}
+                              >
+                                {b.name}
+                              </button>
+                            ))}
+                          </div>
+                        ))
+                      )}
+                    </div>
+                  </div>
+                </>
+              ) : null}
+            </div>
+          );
+        })()
       )}
 
       {sel ? (

--- a/apps/desktop/src/styles/global.css
+++ b/apps/desktop/src/styles/global.css
@@ -1171,6 +1171,42 @@
   outline-offset: 1px;
 }
 
+/* 楼栋搜索下拉（filter-dd 变体）：搜索框 + 分组滚动列表 */
+.washer-dd-search {
+  height: 30px;
+  min-height: 0;
+  font-size: 12px;
+  margin-bottom: 6px;
+}
+.washer-dd-list {
+  max-height: 280px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.washer-dd-group {
+  padding: 7px 10px 4px;
+  font-size: 11px;
+  color: var(--text-3, rgba(0, 0, 0, 0.45));
+  line-height: 1;
+}
+.washer-dd-opt {
+  width: 100%;
+  border: none;
+  background: none;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+}
+.washer-dd-opt.is-sel { color: var(--accent); font-weight: 600; }
+.washer-dd-empty {
+  padding: 12px 10px;
+  font-size: 12px;
+  color: var(--text-3, rgba(0, 0, 0, 0.45));
+  text-align: center;
+}
+
 /* 设备网格：自适应列宽，拥挤与稀疏都可控 */
 .washer-grid {
   display: grid;


### PR DESCRIPTION
Fixes #6

## 改动

**`apps/desktop/src/pages/info/WasherTab.tsx`** — 把原生 `<select>`（只能下翻）换成项目已有的 `filter-dd` 下拉模式，并加搜索框：

- 点击"选择楼栋…"展开面板，顶部搜索框输入即过滤
- 按楼栋名（如"紫荆 1 号楼"输 `1` / `紫荆`）或分组名（输"海乐"展开整组）模糊匹配，大小写不敏感
- 列表保留原有分组结构，最大高度 280px 滚动，无匹配显示"无匹配楼栋"
- 选中后自动收起并清空搜索词；当前楼栋 accent 高亮
- 点面板外关闭（复用 `seg-menu-backdrop`）

**`apps/desktop/src/styles/global.css`** — 新增 `.washer-dd-search / -list / -group / -opt / -empty` 样式，视觉与现有下拉一致。

## 验证

- `tsc --noEmit`（apps/desktop）通过
