### PR TITLE
fix(card): 近 30 天消费统计恒显 ¥0.00（符号判断写反）

### DIFF
--- a/apps/desktop/src/pages/info/CardTab.tsx
+++ b/apps/desktop/src/pages/info/CardTab.tsx
@@ -68,7 +68,7 @@ export function CardTab({ active = true }: { active?: boolean }) {
             <IconCard width={17} height={17} />
           </span>
           <div>
-            <div className="stat-num">{spent < 0 ? `¥${(-spent).toFixed(2)}` : "¥0.00"}</div>
+            <div className="stat-num">¥{spent.toFixed(2)}</div>
             <div className="stat-label">近 30 天消费</div>
           </div>
         </Card>


### PR DESCRIPTION
Closes #10

## 问题

「近 30 天消费」统计卡永远显示 ¥0.00，即使流水列表里有消费记录。

## 原因

`CardTab.tsx` 中 `spent` 是非收入流水 `Math.abs(t.amount)` 求和——**恒为正数**，而渲染条件却写成了 `spent < 0 ? … : "¥0.00"`，永不成立，恒落兜底分支。（疑似从「带符号金额求和」重构为绝对值求和时的遗留。）

## 修复

```diff
- <div className="stat-num">{spent < 0 ? `¥${(-spent).toFixed(2)}` : "¥0.00"}</div>
+ <div className="stat-num">¥{spent.toFixed(2)}</div>
```

`spent = 0` 时 `toFixed(2)` 输出 `"0.00"`，展示不受影响。

## 验证

- ✅ `tsc --noEmit` 通过
- ✅ `vite build` 通过
- 演示模式（demoCardBundle 含消费流水）下统计卡正确显示合计金额

🤖 Generated with [Claude Code](https://claude.com/claude-code)