### PR TITLE
feat(card): 支出统计增强（今日/本周/本年/总支出）+ 卡片管理

### DIFF
--- a/apps/desktop/src/components/Layout.tsx
+++ b/apps/desktop/src/components/Layout.tsx
@@ -512,14 +512,18 @@ export function SectionHead({
 export function Card({
   className = "",
   style,
+  onClick,
+  title,
   children,
 }: {
   className?: string;
   style?: CSSProperties;
+  onClick?: React.MouseEventHandler<HTMLDivElement>;
+  title?: string;
   children: ReactNode;
 }) {
   return (
-    <div className={`card ${className}`} style={style}>
+    <div className={`card ${className}`} style={style} onClick={onClick} title={title}>
       {children}
     </div>
   );

--- a/apps/desktop/src/pages/info/CardTab.tsx
+++ b/apps/desktop/src/pages/info/CardTab.tsx
@@ -1,26 +1,27 @@
 /**
  * 校园卡页 —— getCardInfo + getCardTransactions（thu-info-lib card.ts 移植）。
- * 余额与卡状态置顶；充值（cardRechargeFromBank / cardRechargeQrcode，链路逐条移植自 thu-info-lib）。
- * 支出统计参考 THU-EAT（stats.py/api_summary 口径）：
- * 今日（自然日）/ 本周（周一至今）/ 本年（1 月 1 日至今）/ 总支出（默认全部，
- * 可选自定义日期区间）；全部排除充值/圈存/补助等收入流水。
- * 卡片管理：统计卡可选择性隐藏（localStorage 持久化，homeCards 同款策略）。
+ * 余额与卡状态置顶；充值（cardRechargeFromBank / cardRechargeQrcode，链路逐条移植自 thu-info-lib）；支出统计（THU-EAT
+ * stats.py/api_summary 口径，今日/本周/本年/总支出区间，均排除充值/圈存/补助）。
  * 金额约定（thu-info-app expenditure.tsx 实证）：服务端金额恒为正，
  * 按「名称」分类——充值/圈存/补助=收入（+绿），其余=消费（−红）。
+ *
+ * 请求纪律（PR #13 反馈口径）：首屏仍只拉 30 天；本年/总支出等大窗口
+ * 一律用户点击对应统计后才按精确区间拉取（getCardTxWindow，TTL 缓存 +
+ * in-flight 去重）——轻量请求、不重锤校内服务。
  *
  * 充值安全红线（支付链路）：
  * - 本应用只「下单 + 展示官方收款链」，支付动作完全发生在支付宝/微信/银行侧，不经手资金；
  * - 下单请求不自动重试；响应（学号/收款链接）不写入任何调试日志；
  * - 二次确认明示金额与方式；结果以校园卡余额/流水为准，UI 不宣称「已到账」。
  */
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { QRCodeSVG } from "qrcode.react";
 import type { CardTransaction } from "@onethu/core";
 import { Card, Empty, ErrorNote, SectionHead, SkeletonRows } from "../../components/Layout.js";
 import { IconCard } from "../../components/Icons.js";
 import { useApp } from "../../state/context.js";
-import { useCard } from "../../state/data.js";
+import { getCardTxWindow, useCard } from "../../state/data.js";
 import { info } from "../../lib/clients.js";
 import { openAlipayDeepLink, openExternal } from "./openExternal.js";
 
@@ -33,10 +34,10 @@ const isIncome = (t: CardTransaction): boolean =>
 const signedAmount = (t: CardTransaction): number =>
   isIncome(t) ? Math.abs(t.amount) : -Math.abs(t.amount);
 
-/** 流水拉取窗口：「全部支出」口径按 4 年兜底（单请求 pageSize 10000，服务端截断则如实展示） */
-const HISTORY_DAYS = 365 * 4 + 1;
 /** 最近消费列表/近 30 天统计窗口 */
 const LIST_DAYS = 30;
+/** 「全部」口径的兜底窗口：4 年（仅用户点击总支出后才拉取） */
+const ALL_YEARS_DAYS = 365 * 4 + 1;
 
 /* —— 卡片显隐持久化（默认全显，只记隐藏项）—— */
 const HIDDEN_KEY = "onethu.card-hidden.v1";
@@ -67,10 +68,6 @@ function saveHidden(list: CardKey[]): void {
 
 /* —— 支出统计口径（THU-EAT api_summary 同语义，均排除收入）—— */
 const dayFloor = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
-function withinDays(txs: CardTransaction[], days: number): CardTransaction[] {
-  const lo = dayFloor(new Date()) - (days - 1) * 86400000;
-  return txs.filter((t) => t.timestamp.getTime() >= lo);
-}
 const sumOf = (txs: CardTransaction[]) => txs.reduce((s, t) => s + Math.abs(t.amount), 0);
 
 type TodayMode = "today" | "week" | "year";
@@ -83,13 +80,9 @@ function fmtTime(d: Date): string {
   const mm = String(d.getMinutes()).padStart(2, "0");
   return `${m}-${day} ${hh}:${mm}`;
 }
-/** Date → "YYYY-MM-DD"（date input 受控值） */
+/** Date → "YYYY-MM-DD"（date input 受控值 / 流水接口入参同格式） */
 const isoDate = (d: Date) =>
   `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-
-/* —— 弹窗骨架（zhjwxk 同款：mask/panel 自带表面色）—— */
-const ccMask: React.CSSProperties = { position: "fixed", inset: 0, background: "rgba(0,0,0,.45)", zIndex: 1000, display: "flex", alignItems: "center", justifyContent: "center", padding: 24 };
-const ccPanel: React.CSSProperties = { width: "100%", maxWidth: 420, maxHeight: "70vh", display: "flex", flexDirection: "column", background: "var(--bg-elev, #ffffff)", color: "var(--text, #1f2329)", borderRadius: 14, boxShadow: "0 18px 50px rgba(0,0,0,.28)" };
 
 /* ---------------- 充值弹窗（form → confirm → qr / bankDone） ---------------- */
 
@@ -258,16 +251,97 @@ function RechargeDialog({ open, onClose, onPaid }: { open: boolean; onClose: () 
   );
 }
 
+/* ---------------- 总支出区间选择弹窗（选完才拉取，带加载/错误态） ---------------- */
+
+function RangeDialog({
+  open,
+  onClose,
+  busy,
+  err,
+  rangeStart,
+  rangeEnd,
+  setRange,
+  onSubmit,
+}: {
+  open: boolean;
+  onClose: () => void;
+  busy: boolean;
+  err: string;
+  rangeStart: string;
+  rangeEnd: string;
+  setRange: (start: string, end: string) => void;
+  onSubmit: () => void;
+}) {
+  if (!open) return null;
+  return createPortal(
+    <div style={maskStyle} onClick={onClose}>
+      <div style={panelStyle} onClick={(e) => e.stopPropagation()}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10 }}>
+          <b>总支出统计区间</b>
+          <span style={{ flex: 1 }} />
+          <button className="btn" onClick={onClose}>✕</button>
+        </div>
+        <div style={{ fontSize: 12, opacity: 0.65, marginBottom: 10 }}>
+          选择区间后才会向校园卡服务发起对应窗口的流水请求（结果缓存 10 分钟）。
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 10 }}>
+          <button
+            className="btn"
+            onClick={() => {
+              const s = new Date();
+              s.setDate(s.getDate() - ALL_YEARS_DAYS + 1);
+              setRange(isoDate(s), isoDate(new Date()));
+            }}
+          >
+            全部（近 4 年）
+          </button>
+          <button
+            className="btn"
+            onClick={() => {
+              const y = new Date().getFullYear();
+              setRange(`${y}-01-01`, isoDate(new Date()));
+            }}
+          >
+            本年
+          </button>
+          <button
+            className="btn"
+            onClick={() => {
+              const s = new Date();
+              s.setDate(s.getDate() - 364);
+              setRange(isoDate(s), isoDate(new Date()));
+            }}
+          >
+            近一年
+          </button>
+        </div>
+        <div style={{ display: "flex", gap: 8, alignItems: "center", marginBottom: 10 }}>
+          <span style={{ color: "var(--text-3, #9aa1ac)", fontSize: 12 }}>自定</span>
+          <input className="input" type="date" value={rangeStart} onChange={(e) => setRange(e.target.value, rangeEnd)} />
+          <span>至</span>
+          <input className="input" type="date" value={rangeEnd} onChange={(e) => setRange(rangeStart, e.target.value)} />
+        </div>
+        {err ? <div style={{ color: "#d33", fontSize: 12, marginBottom: 8 }}>{err}</div> : null}
+        <button className="btn btn-primary" style={{ width: "100%" }} disabled={busy || !rangeStart || !rangeEnd} onClick={onSubmit}>
+          {busy ? "拉取流水中…" : "统计该区间支出"}
+        </button>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
 /* --------------------------------- 主组件 --------------------------------- */
 
 export function CardTab({ active = true }: { active?: boolean }) {
   const { status } = useApp();
-  const { data, state, error, reload } = useCard(HISTORY_DAYS);
+  const demo = status === "demo";
+  const { data, state, error, reload } = useCard(30);
   const [rchOpen, setRchOpen] = useState(false);
   // 切回本栏时若上次报错（如会话过期）则自动重试一次，不再让用户手动点刷新
   useEffect(() => { if (active && state === "error") void reload(); }, [active]);
 
-  /** 全量支出流水（排除收入，时间倒序） */
+  /** 首屏 30 天窗口内的消费流水（排除收入，时间倒序）——今日/本周/近30天/笔数全在此算，零额外请求 */
   const spentTxs = useMemo(
     () =>
       (data?.transactions ?? [])
@@ -275,43 +349,79 @@ export function CardTab({ active = true }: { active?: boolean }) {
         .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime()),
     [data],
   );
-  const listTxs = useMemo(() => withinDays(spentTxs.concat((data?.transactions ?? []).filter(isIncome)), LIST_DAYS), [spentTxs, data]);
-  const last30 = useMemo(() => sumOf(listTxs.filter((t) => !isIncome(t))), [listTxs]);
+  /** 最近消费列表：首屏 30 天窗口内全部流水（含收入，充值/圈存也展示） */
+  const listTxs = useMemo(() => data?.transactions ?? [], [data]);
+  const last30 = useMemo(() => sumOf(spentTxs), [spentTxs]);
 
-  /* 今日/本周/本年（点击切换，自然周期口径） */
+  /* —— 今日/本周/本年（点击切换，自然周期口径）—— */
   const [todayMode, setTodayMode] = useState<TodayMode>("today");
+  const [yearTxs, setYearTxs] = useState<CardTransaction[] | null>(null);
+  const [yearState, setYearState] = useState<"idle" | "loading" | "error">("idle");
+
+  // 本年超出 30 天首屏窗口 → 按需拉取 [1月1日, 今天]；ref 守卫防 effect 自触发循环，
+  // 失败清守卫 → 用户切走再切回本年即重试（缓存命中时 getCardTxWindow 不发请求）
+  const yearTried = useRef(false);
+  useEffect(() => {
+    if (todayMode !== "year" || yearTried.current) return;
+    yearTried.current = true;
+    let alive = true;
+    setYearState("loading");
+    const jan1 = new Date(new Date().getFullYear(), 0, 1);
+    getCardTxWindow(jan1, new Date(), demo)
+      .then((txs) => {
+        if (!alive) return;
+        setYearTxs(txs.filter((t) => !isIncome(t)));
+        setYearState("idle");
+      })
+      .catch(() => {
+        yearTried.current = false;
+        if (alive) setYearState("error");
+      });
+    return () => {
+      alive = false;
+    };
+  }, [todayMode, demo]);
+
   const periodSum = useMemo(() => {
     const now = new Date();
-    if (todayMode === "today") {
-      const lo = dayFloor(now);
-      return sumOf(spentTxs.filter((t) => t.timestamp.getTime() >= lo));
-    }
+    if (todayMode === "today") return sumOf(spentTxs.filter((t) => t.timestamp.getTime() >= dayFloor(now)));
     if (todayMode === "week") {
       const monday = dayFloor(new Date(now.getFullYear(), now.getMonth(), now.getDate() - ((now.getDay() + 6) % 7)));
       return sumOf(spentTxs.filter((t) => t.timestamp.getTime() >= monday));
     }
-    const yearStart = dayFloor(new Date(now.getFullYear(), 0, 1));
-    return sumOf(spentTxs.filter((t) => t.timestamp.getTime() >= yearStart));
-  }, [spentTxs, todayMode]);
+    return sumOf(yearTxs ?? []);
+  }, [spentTxs, todayMode, yearTxs]);
 
-  /* 总支出：默认全部；自定义区间（"YYYY-MM-DD"） */
+  /* —— 总支出：默认不拉取，卡片保留占位；点击选区间后才请求对应窗口 —— */
+  const [totalTxs, setTotalTxs] = useState<CardTransaction[] | null>(null);
+  const [totalLabel, setTotalLabel] = useState("");
+  const [totalBusy, setTotalBusy] = useState(false);
+  const [totalErr, setTotalErr] = useState("");
   const [rangeStart, setRangeStart] = useState("");
   const [rangeEnd, setRangeEnd] = useState("");
-  const custom = rangeStart || rangeEnd;
-  const totalSum = useMemo(() => {
-    if (!custom) return sumOf(spentTxs);
-    const lo = rangeStart ? dayFloor(new Date(rangeStart.replace(/-/g, "/"))) : -Infinity;
-    const hi = rangeEnd ? dayFloor(new Date(rangeEnd.replace(/-/g, "/"))) + 86400000 : Infinity;
-    return sumOf(spentTxs.filter((t) => {
-      const x = t.timestamp.getTime();
-      return x >= lo && x < hi;
-    }));
-  }, [spentTxs, rangeStart, rangeEnd]);
+  const [rangeOpen, setRangeOpen] = useState(false);
+  const totalSum = useMemo(() => sumOf(totalTxs ?? []), [totalTxs]);
 
-  /* 卡片显隐管理 */
+  const submitRange = async () => {
+    setTotalBusy(true);
+    setTotalErr("");
+    // "YYYY-MM-DD" → 本地零点（避免 new Date("2026-01-01") 按 UTC 解析偏一天）
+    const parse = (s: string) => new Date(s.replace(/-/g, "/"));
+    try {
+      const txs = await getCardTxWindow(parse(rangeStart), parse(rangeEnd), demo);
+      setTotalTxs(txs.filter((t) => !isIncome(t)));
+      setTotalLabel(`${rangeStart} ~ ${rangeEnd}`);
+      setRangeOpen(false);
+    } catch (e) {
+      setTotalErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setTotalBusy(false);
+    }
+  };
+
+  /* —— 卡片显隐管理 —— */
   const [hidden, setHidden] = useState<CardKey[]>(loadHidden);
   const [manageOpen, setManageOpen] = useState(false);
-  const [rangeOpen, setRangeOpen] = useState(false);
   const show = (k: CardKey) => !hidden.includes(k);
   const toggleHidden = (k: CardKey) => {
     const next = hidden.includes(k) ? hidden.filter((x) => x !== k) : [...hidden, k];
@@ -343,7 +453,7 @@ export function CardTab({ active = true }: { active?: boolean }) {
                   {data?.info.cardStatus ? ` · ${data.info.cardStatus}` : ""}
                 </div>
               </div>
-              {status !== "demo" ? (
+              {!demo ? (
                 <button className="btn btn-primary" style={{ marginLeft: "auto", height: 30 }} onClick={() => setRchOpen(true)}>
                   充值
                 </button>
@@ -369,8 +479,15 @@ export function CardTab({ active = true }: { active?: boolean }) {
               <IconCard width={17} height={17} />
             </span>
             <div>
-              <div className="stat-num">¥{periodSum.toFixed(2)}</div>
-              <div className="stat-label">{TODAY_LABEL[todayMode]} · 点击切换</div>
+              <div className="stat-num">
+                {todayMode === "year" && yearState === "loading" ? "…" : todayMode === "year" && yearState === "error" ? "–" : `¥${periodSum.toFixed(2)}`}
+              </div>
+              <div className="stat-label">
+                {TODAY_LABEL[todayMode]}
+                {todayMode === "year" && yearState === "loading" ? " · 拉取中"
+                  : todayMode === "year" && yearState === "error" ? " · 拉取失败，切回再试"
+                  : " · 点击切换"}
+              </div>
             </div>
           </Card>
         ) : null}
@@ -390,15 +507,15 @@ export function CardTab({ active = true }: { active?: boolean }) {
             className="stat-card"
             style={{ cursor: "pointer" }}
             onClick={() => setRangeOpen(true)}
-            title="点击选择统计区间（默认全部）"
+            title="点击选择统计区间（选择后才会拉取对应窗口流水）"
           >
             <span className="stat-icon amber">
               <IconCard width={17} height={17} />
             </span>
             <div>
-              <div className="stat-num">¥{totalSum.toFixed(2)}</div>
+              <div className="stat-num">{totalTxs ? `¥${totalSum.toFixed(2)}` : "¥–"}</div>
               <div className="stat-label">
-                总支出{custom ? ` · ${rangeStart || "…"}~${rangeEnd || "…"}` : " · 全部"} · 点击选区间
+                总支出{totalTxs ? ` · ${totalLabel}` : " · 点击选区间拉取"}
               </div>
             </div>
           </Card>
@@ -409,7 +526,7 @@ export function CardTab({ active = true }: { active?: boolean }) {
               <IconCard width={17} height={17} />
             </span>
             <div>
-              <div className="stat-num">{listTxs.filter((t) => !isIncome(t)).length}</div>
+              <div className="stat-num">{spentTxs.length}</div>
               <div className="stat-label">近 30 天笔数</div>
             </div>
           </Card>
@@ -452,17 +569,31 @@ export function CardTab({ active = true }: { active?: boolean }) {
 
       <RechargeDialog open={rchOpen} onClose={() => setRchOpen(false)} onPaid={() => void reload()} />
 
+      <RangeDialog
+        open={rangeOpen}
+        onClose={() => setRangeOpen(false)}
+        busy={totalBusy}
+        err={totalErr}
+        rangeStart={rangeStart}
+        rangeEnd={rangeEnd}
+        setRange={(s, e) => {
+          setRangeStart(s);
+          setRangeEnd(e);
+        }}
+        onSubmit={() => void submitRange()}
+      />
+
       {/* 卡片管理弹窗 */}
       {manageOpen
         ? createPortal(
-            <div style={ccMask} onClick={() => setManageOpen(false)}>
-              <div style={ccPanel} onClick={(e) => e.stopPropagation()}>
-                <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "12px 16px", borderBottom: "1px solid var(--border, #eee)" }}>
+            <div style={maskStyle} onClick={() => setManageOpen(false)}>
+              <div style={panelStyle} onClick={(e) => e.stopPropagation()}>
+                <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10 }}>
                   <b>管理统计卡片</b>
                   <span style={{ flex: 1 }} />
                   <button className="btn" onClick={() => setManageOpen(false)}>✕</button>
                 </div>
-                <div style={{ padding: "12px 16px", fontSize: 13, lineHeight: 1.8 }}>
+                <div style={{ fontSize: 13, lineHeight: 1.8 }}>
                   {CARD_LABELS.map((c) => (
                     <label key={c.key} style={{ display: "flex", alignItems: "center", gap: 8, padding: "4px 0", cursor: "pointer" }}>
                       <input type="checkbox" checked={show(c.key)} onChange={() => toggleHidden(c.key)} />
@@ -480,60 +611,6 @@ export function CardTab({ active = true }: { active?: boolean }) {
                       恢复默认
                     </button>
                     <button className="btn btn-primary" onClick={() => setManageOpen(false)}>完成</button>
-                  </div>
-                </div>
-              </div>
-            </div>,
-            document.body,
-          )
-        : null}
-
-      {/* 总支出区间选择弹窗 */}
-      {rangeOpen
-        ? createPortal(
-            <div style={ccMask} onClick={() => setRangeOpen(false)}>
-              <div style={ccPanel} onClick={(e) => e.stopPropagation()}>
-                <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "12px 16px", borderBottom: "1px solid var(--border, #eee)" }}>
-                  <b>总支出统计区间</b>
-                  <span style={{ flex: 1 }} />
-                  <button className="btn" onClick={() => setRangeOpen(false)}>✕</button>
-                </div>
-                <div style={{ padding: "12px 16px", fontSize: 13, lineHeight: 1.8, display: "grid", gap: 10 }}>
-                  <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-                    <button className="btn" onClick={() => { setRangeStart(""); setRangeEnd(""); }}>全部（默认）</button>
-                    <button
-                      className="btn"
-                      onClick={() => {
-                        const y = new Date().getFullYear();
-                        setRangeStart(`${y}-01-01`);
-                        setRangeEnd(isoDate(new Date()));
-                      }}
-                    >
-                      本年
-                    </button>
-                    <button
-                      className="btn"
-                      onClick={() => {
-                        const s = new Date();
-                        s.setDate(s.getDate() - 364);
-                        setRangeStart(isoDate(s));
-                        setRangeEnd(isoDate(new Date()));
-                      }}
-                    >
-                      近一年
-                    </button>
-                  </div>
-                  <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-                    <span style={{ color: "var(--text-3, #9aa1ac)", fontSize: 12 }}>自定</span>
-                    <input className="input" type="date" value={rangeStart} onChange={(e) => setRangeStart(e.target.value)} />
-                    <span>至</span>
-                    <input className="input" type="date" value={rangeEnd} onChange={(e) => setRangeEnd(e.target.value)} />
-                  </div>
-                  <div style={{ fontSize: 12, color: "var(--text-3, #9aa1ac)" }}>
-                    支出统计均排除充值/圈存/补助；「全部」为可拉取的全部流水（近 4 年）。
-                  </div>
-                  <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
-                    <button className="btn btn-primary" onClick={() => setRangeOpen(false)}>应用</button>
                   </div>
                 </div>
               </div>

--- a/apps/desktop/src/pages/info/CardTab.tsx
+++ b/apps/desktop/src/pages/info/CardTab.tsx
@@ -1,7 +1,10 @@
 /**
  * 校园卡页 —— getCardInfo + getCardTransactions（thu-info-lib card.ts 移植）。
- * 余额与卡状态置顶；最近 30 天消费流水；充值（cardRechargeFromBank /
- * cardRechargeQrcode，链路逐条移植自 thu-info-lib）。
+ * 余额与卡状态置顶；充值（cardRechargeFromBank / cardRechargeQrcode，链路逐条移植自 thu-info-lib）。
+ * 支出统计参考 THU-EAT（stats.py/api_summary 口径）：
+ * 今日（自然日）/ 本周（周一至今）/ 本年（1 月 1 日至今）/ 总支出（默认全部，
+ * 可选自定义日期区间）；全部排除充值/圈存/补助等收入流水。
+ * 卡片管理：统计卡可选择性隐藏（localStorage 持久化，homeCards 同款策略）。
  * 金额约定（thu-info-app expenditure.tsx 实证）：服务端金额恒为正，
  * 按「名称」分类——充值/圈存/补助=收入（+绿），其余=消费（−红）。
  *
@@ -30,6 +33,49 @@ const isIncome = (t: CardTransaction): boolean =>
 const signedAmount = (t: CardTransaction): number =>
   isIncome(t) ? Math.abs(t.amount) : -Math.abs(t.amount);
 
+/** 流水拉取窗口：「全部支出」口径按 4 年兜底（单请求 pageSize 10000，服务端截断则如实展示） */
+const HISTORY_DAYS = 365 * 4 + 1;
+/** 最近消费列表/近 30 天统计窗口 */
+const LIST_DAYS = 30;
+
+/* —— 卡片显隐持久化（默认全显，只记隐藏项）—— */
+const HIDDEN_KEY = "onethu.card-hidden.v1";
+type CardKey = "balance" | "today" | "last30" | "total" | "count";
+const CARD_LABELS: Array<{ key: CardKey; label: string }> = [
+  { key: "balance", label: "校园卡余额" },
+  { key: "today", label: "今日支出（可切换本周/本年）" },
+  { key: "last30", label: "近 30 天消费" },
+  { key: "total", label: "总支出（可选日期区间）" },
+  { key: "count", label: "近 30 天笔数" },
+];
+function loadHidden(): CardKey[] {
+  try {
+    const raw = globalThis.localStorage?.getItem(HIDDEN_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed.filter((k) => CARD_LABELS.some((c) => c.key === k)) : [];
+  } catch {
+    return [];
+  }
+}
+function saveHidden(list: CardKey[]): void {
+  try {
+    globalThis.localStorage?.setItem(HIDDEN_KEY, JSON.stringify(list));
+  } catch {
+    /* 存储不可用：会话内仍生效 */
+  }
+}
+
+/* —— 支出统计口径（THU-EAT api_summary 同语义，均排除收入）—— */
+const dayFloor = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+function withinDays(txs: CardTransaction[], days: number): CardTransaction[] {
+  const lo = dayFloor(new Date()) - (days - 1) * 86400000;
+  return txs.filter((t) => t.timestamp.getTime() >= lo);
+}
+const sumOf = (txs: CardTransaction[]) => txs.reduce((s, t) => s + Math.abs(t.amount), 0);
+
+type TodayMode = "today" | "week" | "year";
+const TODAY_LABEL: Record<TodayMode, string> = { today: "今日支出", week: "本周支出", year: "本年支出" };
+
 function fmtTime(d: Date): string {
   const m = String(d.getMonth() + 1).padStart(2, "0");
   const day = String(d.getDate()).padStart(2, "0");
@@ -37,6 +83,13 @@ function fmtTime(d: Date): string {
   const mm = String(d.getMinutes()).padStart(2, "0");
   return `${m}-${day} ${hh}:${mm}`;
 }
+/** Date → "YYYY-MM-DD"（date input 受控值） */
+const isoDate = (d: Date) =>
+  `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+
+/* —— 弹窗骨架（zhjwxk 同款：mask/panel 自带表面色）—— */
+const ccMask: React.CSSProperties = { position: "fixed", inset: 0, background: "rgba(0,0,0,.45)", zIndex: 1000, display: "flex", alignItems: "center", justifyContent: "center", padding: 24 };
+const ccPanel: React.CSSProperties = { width: "100%", maxWidth: 420, maxHeight: "70vh", display: "flex", flexDirection: "column", background: "var(--bg-elev, #ffffff)", color: "var(--text, #1f2329)", borderRadius: 14, boxShadow: "0 18px 50px rgba(0,0,0,.28)" };
 
 /* ---------------- 充值弹窗（form → confirm → qr / bankDone） ---------------- */
 
@@ -209,82 +262,172 @@ function RechargeDialog({ open, onClose, onPaid }: { open: boolean; onClose: () 
 
 export function CardTab({ active = true }: { active?: boolean }) {
   const { status } = useApp();
-  const { data, state, error, reload } = useCard(30);
+  const { data, state, error, reload } = useCard(HISTORY_DAYS);
   const [rchOpen, setRchOpen] = useState(false);
   // 切回本栏时若上次报错（如会话过期）则自动重试一次，不再让用户手动点刷新
   useEffect(() => { if (active && state === "error") void reload(); }, [active]);
 
-  const spent = useMemo(
+  /** 全量支出流水（排除收入，时间倒序） */
+  const spentTxs = useMemo(
     () =>
       (data?.transactions ?? [])
         .filter((t) => !isIncome(t))
-        .reduce((sum, t) => sum + Math.abs(t.amount), 0),
+        .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime()),
     [data],
   );
+  const listTxs = useMemo(() => withinDays(spentTxs.concat((data?.transactions ?? []).filter(isIncome)), LIST_DAYS), [spentTxs, data]);
+  const last30 = useMemo(() => sumOf(listTxs.filter((t) => !isIncome(t))), [listTxs]);
+
+  /* 今日/本周/本年（点击切换，自然周期口径） */
+  const [todayMode, setTodayMode] = useState<TodayMode>("today");
+  const periodSum = useMemo(() => {
+    const now = new Date();
+    if (todayMode === "today") {
+      const lo = dayFloor(now);
+      return sumOf(spentTxs.filter((t) => t.timestamp.getTime() >= lo));
+    }
+    if (todayMode === "week") {
+      const monday = dayFloor(new Date(now.getFullYear(), now.getMonth(), now.getDate() - ((now.getDay() + 6) % 7)));
+      return sumOf(spentTxs.filter((t) => t.timestamp.getTime() >= monday));
+    }
+    const yearStart = dayFloor(new Date(now.getFullYear(), 0, 1));
+    return sumOf(spentTxs.filter((t) => t.timestamp.getTime() >= yearStart));
+  }, [spentTxs, todayMode]);
+
+  /* 总支出：默认全部；自定义区间（"YYYY-MM-DD"） */
+  const [rangeStart, setRangeStart] = useState("");
+  const [rangeEnd, setRangeEnd] = useState("");
+  const custom = rangeStart || rangeEnd;
+  const totalSum = useMemo(() => {
+    if (!custom) return sumOf(spentTxs);
+    const lo = rangeStart ? dayFloor(new Date(rangeStart.replace(/-/g, "/"))) : -Infinity;
+    const hi = rangeEnd ? dayFloor(new Date(rangeEnd.replace(/-/g, "/"))) + 86400000 : Infinity;
+    return sumOf(spentTxs.filter((t) => {
+      const x = t.timestamp.getTime();
+      return x >= lo && x < hi;
+    }));
+  }, [spentTxs, rangeStart, rangeEnd]);
+
+  /* 卡片显隐管理 */
+  const [hidden, setHidden] = useState<CardKey[]>(loadHidden);
+  const [manageOpen, setManageOpen] = useState(false);
+  const [rangeOpen, setRangeOpen] = useState(false);
+  const show = (k: CardKey) => !hidden.includes(k);
+  const toggleHidden = (k: CardKey) => {
+    const next = hidden.includes(k) ? hidden.filter((x) => x !== k) : [...hidden, k];
+    setHidden(next);
+    saveHidden(next);
+  };
 
   return (
     <>
+      <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: 8 }}>
+        <button className="btn" onClick={() => setManageOpen(true)} title="选择要显示的统计卡片">
+          管理卡片
+        </button>
+      </div>
+
       <div className="stats stats-hero">
-        <Card className="card-hero">
-          <div className="card-hero-main">
+        {show("balance") ? (
+          <Card className="card-hero">
+            <div className="card-hero-main">
+              <span className="stat-icon">
+                <IconCard width={17} height={17} />
+              </span>
+              <div>
+                <div className="card-hero-amount">
+                  {state === "loading" && !data ? "–" : `¥${(data?.info.balance ?? 0).toFixed(2)}`}
+                </div>
+                <div className="stat-label">
+                  校园卡余额 · {data?.info.userName || "–"}
+                  {data?.info.cardStatus ? ` · ${data.info.cardStatus}` : ""}
+                </div>
+              </div>
+              {status !== "demo" ? (
+                <button className="btn btn-primary" style={{ marginLeft: "auto", height: 30 }} onClick={() => setRchOpen(true)}>
+                  充值
+                </button>
+              ) : null}
+            </div>
+            <div className="card-hero-meta">
+              <span>卡号 {data?.info.cardId || "–"}</span>
+              {data?.info.departmentName ? <span>{data.info.departmentName}</span> : null}
+              {data?.info.maxOneTimeTransactionAmount !== undefined ? (
+                <span>单笔上限 ¥{data.info.maxOneTimeTransactionAmount.toFixed(0)}</span>
+              ) : null}
+            </div>
+          </Card>
+        ) : null}
+        {show("today") ? (
+          <Card
+            className="stat-card"
+            style={{ cursor: "pointer" }}
+            onClick={() => setTodayMode((m) => (m === "today" ? "week" : m === "week" ? "year" : "today"))}
+            title="点击切换：今日 → 本周 → 本年"
+          >
             <span className="stat-icon">
               <IconCard width={17} height={17} />
             </span>
             <div>
-              <div className="card-hero-amount">
-                {state === "loading" && !data ? "–" : `¥${(data?.info.balance ?? 0).toFixed(2)}`}
-              </div>
+              <div className="stat-num">¥{periodSum.toFixed(2)}</div>
+              <div className="stat-label">{TODAY_LABEL[todayMode]} · 点击切换</div>
+            </div>
+          </Card>
+        ) : null}
+        {show("last30") ? (
+          <Card className="stat-card">
+            <span className="stat-icon red">
+              <IconCard width={17} height={17} />
+            </span>
+            <div>
+              <div className="stat-num">¥{last30.toFixed(2)}</div>
+              <div className="stat-label">近 30 天消费</div>
+            </div>
+          </Card>
+        ) : null}
+        {show("total") ? (
+          <Card
+            className="stat-card"
+            style={{ cursor: "pointer" }}
+            onClick={() => setRangeOpen(true)}
+            title="点击选择统计区间（默认全部）"
+          >
+            <span className="stat-icon amber">
+              <IconCard width={17} height={17} />
+            </span>
+            <div>
+              <div className="stat-num">¥{totalSum.toFixed(2)}</div>
               <div className="stat-label">
-                校园卡余额 · {data?.info.userName || "–"}
-                {data?.info.cardStatus ? ` · ${data.info.cardStatus}` : ""}
+                总支出{custom ? ` · ${rangeStart || "…"}~${rangeEnd || "…"}` : " · 全部"} · 点击选区间
               </div>
             </div>
-            {status !== "demo" ? (
-              <button className="btn btn-primary" style={{ marginLeft: "auto", height: 30 }} onClick={() => setRchOpen(true)}>
-                充值
-              </button>
-            ) : null}
-          </div>
-          <div className="card-hero-meta">
-            <span>卡号 {data?.info.cardId || "–"}</span>
-            {data?.info.departmentName ? <span>{data.info.departmentName}</span> : null}
-            {data?.info.maxOneTimeTransactionAmount !== undefined ? (
-              <span>单笔上限 ¥{data.info.maxOneTimeTransactionAmount.toFixed(0)}</span>
-            ) : null}
-          </div>
-        </Card>
-        <Card className="stat-card">
-          <span className="stat-icon red">
-            <IconCard width={17} height={17} />
-          </span>
-          <div>
-            <div className="stat-num">¥{spent.toFixed(2)}</div>
-            <div className="stat-label">近 30 天消费</div>
-          </div>
-        </Card>
-        <Card className="stat-card">
-          <span className="stat-icon amber">
-            <IconCard width={17} height={17} />
-          </span>
-          <div>
-            <div className="stat-num">{data?.transactions.length ?? 0}</div>
-            <div className="stat-label">流水笔数</div>
-          </div>
-        </Card>
+          </Card>
+        ) : null}
+        {show("count") ? (
+          <Card className="stat-card">
+            <span className="stat-icon">
+              <IconCard width={17} height={17} />
+            </span>
+            <div>
+              <div className="stat-num">{listTxs.filter((t) => !isIncome(t)).length}</div>
+              <div className="stat-label">近 30 天笔数</div>
+            </div>
+          </Card>
+        ) : null}
       </div>
 
       {state === "error" ? <ErrorNote text={error ?? ""} onRetry={() => void reload()} /> : null}
 
-      <SectionHead title="最近消费" aside="最近 30 天（数据源：card.tsinghua.edu.cn）" />
+      <SectionHead title="最近消费" aside={`最近 ${LIST_DAYS} 天（数据源：card.tsinghua.edu.cn）`} />
       {state === "loading" && !data ? (
         <SkeletonRows rows={6} />
-      ) : (data?.transactions.length ?? 0) === 0 ? (
+      ) : listTxs.length === 0 ? (
         <Card>
-          <Empty text="近 30 天没有消费记录。" />
+          <Empty text={`近 ${LIST_DAYS} 天没有消费记录。`} />
         </Card>
       ) : (
         <Card className="list">
-          {data!.transactions.map((t, i) => (
+          {listTxs.map((t, i) => (
             <div className="row" key={t.id || i} style={{ animationDelay: `${Math.min(i, 12) * 25}ms` }}>
               <div className="row-when">
                 <b>{fmtTime(t.timestamp).slice(0, 5)}</b>
@@ -308,6 +451,96 @@ export function CardTab({ active = true }: { active?: boolean }) {
       )}
 
       <RechargeDialog open={rchOpen} onClose={() => setRchOpen(false)} onPaid={() => void reload()} />
+
+      {/* 卡片管理弹窗 */}
+      {manageOpen
+        ? createPortal(
+            <div style={ccMask} onClick={() => setManageOpen(false)}>
+              <div style={ccPanel} onClick={(e) => e.stopPropagation()}>
+                <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "12px 16px", borderBottom: "1px solid var(--border, #eee)" }}>
+                  <b>管理统计卡片</b>
+                  <span style={{ flex: 1 }} />
+                  <button className="btn" onClick={() => setManageOpen(false)}>✕</button>
+                </div>
+                <div style={{ padding: "12px 16px", fontSize: 13, lineHeight: 1.8 }}>
+                  {CARD_LABELS.map((c) => (
+                    <label key={c.key} style={{ display: "flex", alignItems: "center", gap: 8, padding: "4px 0", cursor: "pointer" }}>
+                      <input type="checkbox" checked={show(c.key)} onChange={() => toggleHidden(c.key)} />
+                      {c.label}
+                    </label>
+                  ))}
+                  <div style={{ display: "flex", gap: 8, marginTop: 12, justifyContent: "flex-end" }}>
+                    <button
+                      className="btn"
+                      onClick={() => {
+                        setHidden([]);
+                        saveHidden([]);
+                      }}
+                    >
+                      恢复默认
+                    </button>
+                    <button className="btn btn-primary" onClick={() => setManageOpen(false)}>完成</button>
+                  </div>
+                </div>
+              </div>
+            </div>,
+            document.body,
+          )
+        : null}
+
+      {/* 总支出区间选择弹窗 */}
+      {rangeOpen
+        ? createPortal(
+            <div style={ccMask} onClick={() => setRangeOpen(false)}>
+              <div style={ccPanel} onClick={(e) => e.stopPropagation()}>
+                <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "12px 16px", borderBottom: "1px solid var(--border, #eee)" }}>
+                  <b>总支出统计区间</b>
+                  <span style={{ flex: 1 }} />
+                  <button className="btn" onClick={() => setRangeOpen(false)}>✕</button>
+                </div>
+                <div style={{ padding: "12px 16px", fontSize: 13, lineHeight: 1.8, display: "grid", gap: 10 }}>
+                  <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                    <button className="btn" onClick={() => { setRangeStart(""); setRangeEnd(""); }}>全部（默认）</button>
+                    <button
+                      className="btn"
+                      onClick={() => {
+                        const y = new Date().getFullYear();
+                        setRangeStart(`${y}-01-01`);
+                        setRangeEnd(isoDate(new Date()));
+                      }}
+                    >
+                      本年
+                    </button>
+                    <button
+                      className="btn"
+                      onClick={() => {
+                        const s = new Date();
+                        s.setDate(s.getDate() - 364);
+                        setRangeStart(isoDate(s));
+                        setRangeEnd(isoDate(new Date()));
+                      }}
+                    >
+                      近一年
+                    </button>
+                  </div>
+                  <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                    <span style={{ color: "var(--text-3, #9aa1ac)", fontSize: 12 }}>自定</span>
+                    <input className="input" type="date" value={rangeStart} onChange={(e) => setRangeStart(e.target.value)} />
+                    <span>至</span>
+                    <input className="input" type="date" value={rangeEnd} onChange={(e) => setRangeEnd(e.target.value)} />
+                  </div>
+                  <div style={{ fontSize: 12, color: "var(--text-3, #9aa1ac)" }}>
+                    支出统计均排除充值/圈存/补助；「全部」为可拉取的全部流水（近 4 年）。
+                  </div>
+                  <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+                    <button className="btn btn-primary" onClick={() => setRangeOpen(false)}>应用</button>
+                  </div>
+                </div>
+              </div>
+            </div>,
+            document.body,
+          )
+        : null}
     </>
   );
 }

--- a/apps/desktop/src/state/data.ts
+++ b/apps/desktop/src/state/data.ts
@@ -1801,6 +1801,59 @@ export function useCard(days = 30) {
   return { data, state, error, reload };
 }
 
+/* ============ 校园卡流水区间缓存（按需拉取，PR #13 返工口径） ============
+ * 首屏仍只拉 30 天（useCard 原路径，含 localStorage 冷启动缓存）；
+ * 本年/总支出等大窗口只在用户点击对应统计时拉取，结果按窗口缓存（TTL 10 分钟），
+ * 命中「覆盖且未过期」的窗口直接本地切片，绝不重复请求——轻量请求、不重锤校内服务。
+ * 内存级缓存（不走 PERSISTED 名单）：大窗口流水不占 localStorage 配额。 */
+
+/** 区间缓存 TTL：校园卡流水分钟级变化无统计意义，10 分钟内切换区间零请求 */
+const CARD_TX_RANGE_TTL = 10 * 60 * 1000;
+
+interface CardTxWindow {
+  start: number;
+  end: number;
+  txs: CardTransaction[];
+  at: number;
+}
+
+const cardTxWindows: CardTxWindow[] = [];
+const cardTxRangeInflight = new Map<string, Promise<CardTransaction[]>>();
+
+/**
+ * 按需拉取 [start,end] 消费/收入流水（含端点日）。
+ * demo 模式从 demo bundle 按时间切片，不发请求。
+ * 命中条件：存在窗口 w 满足 w.start<=start && w.end>=end 且未过期 → 本地切片返回。
+ */
+export async function getCardTxWindow(start: Date, end: Date, demo: boolean): Promise<CardTransaction[]> {
+  const lo = start.getTime();
+  const hi = end.getTime();
+  if (demo) {
+    const all = demoCardBundle().transactions;
+    return all.filter((t) => t.timestamp.getTime() >= lo && t.timestamp.getTime() <= hi + 86400000);
+  }
+  const now = Date.now();
+  const covered = cardTxWindows.find((w) => w.start <= lo && w.end >= hi && now - w.at < CARD_TX_RANGE_TTL);
+  if (covered) return covered.txs.filter((t) => t.timestamp.getTime() >= lo);
+
+  const key = `${fmtDate(start)}~${fmtDate(end)}`;
+  const running = cardTxRangeInflight.get(key);
+  if (running) return running;
+  const p = info
+    .getCardTransactions(fmtDate(start), fmtDate(end))
+    .then((txs) => {
+      cardTxWindows.push({ start: lo, end: hi, txs, at: Date.now() });
+      // 上限防膨胀：最多留 8 个窗口，淘汰最旧
+      if (cardTxWindows.length > 8) cardTxWindows.shift();
+      return txs;
+    })
+    .finally(() => {
+      cardTxRangeInflight.delete(key);
+    });
+  cardTxRangeInflight.set(key, p);
+  return p;
+}
+
 /* ============ 今日预约（首页聚合卡：图书馆座位 + 研讨间，按「今天」过滤） ============ */
 
 export interface TodayReservation {


### PR DESCRIPTION
Closes #12

## 改动

参考 [THU-EAT](https://github.com/user-A100/THU-EAT) `stats.py`/`api_summary` 的统计口径，增强校园卡页：

### 新统计卡
- **今日支出**：点击循环 今日 → 本周 → 本年（自然日 / 周一至今 / 1 月 1 日至今）
- **总支出**：默认**全部**；点击弹窗选择区间（全部 / 本年 / 近一年 / 起止日期自定）
- 所有支出统计均排除充值/圈存/补助（THU-EAT `exclude_recharge` 同款口径）

### 卡片管理
- 右上「管理卡片」按钮：五张统计卡（余额 / 今日 / 近 30 天 / 总支出 / 笔数）均可勾选隐藏
- 隐藏配置 localStorage 持久化（`onethu.card-hidden.v1`），支持一键恢复默认

### 数据层
- 流水拉取窗口 30 天 → 4 年（单请求 `pageSize: 10000`，服务端截断则如实展示），支撑「全部」口径
- 近 30 天消费 / 最近消费列表 / 流水笔数口径不变（在本地按 30 天窗口切片）

### 其他
- `Layout.Card` 组件支持 `onClick` / `title`（点击切换卡所需）

## 验证

- ✅ `tsc --noEmit` 通过
- ✅ `vite build` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)