### PR TITLE
feat(info,life): 栏目管理——选择性隐藏 + 顺序调整

### DIFF
--- a/apps/desktop/src/components/TabManageModal.tsx
+++ b/apps/desktop/src/components/TabManageModal.tsx
@@ -1,0 +1,93 @@
+/**
+ * 聚合页栏目管理弹窗：勾选显隐 + ↑↓ 调序 + 恢复默认。
+ * zhjwxk 弹窗同款骨架（portal + mask/panel 自带表面色）。
+ * 布局变更即时生效并经 onApply 回传持久化（tabLayout.saveTabLayout）。
+ */
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+import type { TabLayout } from "../lib/tabLayout.js";
+
+const maskStyle: React.CSSProperties = { position: "fixed", inset: 0, background: "rgba(0,0,0,.45)", zIndex: 1000, display: "flex", alignItems: "center", justifyContent: "center", padding: 24 };
+const panelStyle: React.CSSProperties = { width: "100%", maxWidth: 420, maxHeight: "70vh", display: "flex", flexDirection: "column", background: "var(--bg-elev, #ffffff)", color: "var(--text, #1f2329)", borderRadius: 14, boxShadow: "0 18px 50px rgba(0,0,0,.28)" };
+
+export function TabManageModal({
+  open,
+  onClose,
+  title,
+  tabs,
+  layout,
+  onApply,
+  onReset,
+}: {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  tabs: Array<{ id: string; label: string }>;
+  layout: TabLayout;
+  onApply: (layout: TabLayout) => void;
+  onReset: () => void;
+}) {
+  /* Esc 关闭（即时生效型弹窗：直接关闭即保存，无需确认步骤） */
+  useEffect(() => {
+    if (!open) return;
+    const h = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", h);
+    return () => window.removeEventListener("keydown", h);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const rows = layout.order
+    .map((id) => tabs.find((t) => t.id === id))
+    .filter((t): t is { id: string; label: string } => !!t);
+
+  const toggle = (id: string) =>
+    onApply({
+      order: layout.order,
+      hidden: layout.hidden.includes(id) ? layout.hidden.filter((x) => x !== id) : [...layout.hidden, id],
+    });
+
+  const move = (id: string, delta: -1 | 1) => {
+    const i = layout.order.indexOf(id);
+    const j = i + delta;
+    if (i < 0 || j < 0 || j >= layout.order.length) return;
+    const order = [...layout.order];
+    [order[i], order[j]] = [order[j]!, order[i]!];
+    onApply({ ...layout, order });
+  };
+
+  return createPortal(
+    <div style={maskStyle} onClick={onClose}>
+      <div style={panelStyle} onClick={(e) => e.stopPropagation()}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "12px 16px", borderBottom: "1px solid var(--border, #eee)" }}>
+          <b>{title}</b>
+          <span style={{ flex: 1 }} />
+          <button className="btn" onClick={onClose}>✕</button>
+        </div>
+        <div style={{ padding: "8px 16px 14px", overflowY: "auto", fontSize: 13, lineHeight: 1.7 }}>
+          <div style={{ fontSize: 12, color: "var(--text-3, #9aa1ac)", margin: "6px 0" }}>
+            勾选控制显示；↑↓ 调整顺序（即时生效并保存）。
+          </div>
+          {rows.map((t, i) => {
+            const visible = !layout.hidden.includes(t.id);
+            return (
+              <div key={t.id} style={{ display: "flex", alignItems: "center", gap: 8, padding: "4px 0" }}>
+                <label style={{ display: "flex", alignItems: "center", gap: 8, flex: 1, cursor: "pointer", opacity: visible ? 1 : 0.5 }}>
+                  <input type="checkbox" checked={visible} onChange={() => toggle(t.id)} />
+                  {t.label}
+                </label>
+                <button className="btn" style={{ padding: "1px 8px" }} disabled={i === 0} onClick={() => move(t.id, -1)} title="上移">↑</button>
+                <button className="btn" style={{ padding: "1px 8px" }} disabled={i === rows.length - 1} onClick={() => move(t.id, 1)} title="下移">↓</button>
+              </div>
+            );
+          })}
+          <div style={{ display: "flex", gap: 8, marginTop: 12, justifyContent: "flex-end" }}>
+            <button className="btn" onClick={onReset}>恢复默认</button>
+            <button className="btn btn-primary" onClick={onClose}>完成</button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/desktop/src/lib/tabLayout.ts
+++ b/apps/desktop/src/lib/tabLayout.ts
@@ -1,0 +1,37 @@
+/**
+ * 聚合页栏目布局（显隐 + 顺序）：localStorage 持久化，按页分键。
+ * 读写 try/catch 静默降级（homeCards / customCourses 同款策略）。
+ * 合并规则：存储只记增量（order 存已知 id 的排列，缺失的按默认序追加；
+ * hidden 过滤未知 id）——新增栏目天然可见且排在末尾，升级不丢用户配置。
+ */
+
+export interface TabLayout {
+  /** 栏目排列（已知 id 的某个排列，可能缺项） */
+  order: string[];
+  /** 隐藏的栏目 id */
+  hidden: string[];
+}
+
+export function loadTabLayout(key: string, allIds: string[]): TabLayout {
+  let stored: Partial<TabLayout> | null = null;
+  try {
+    const raw = globalThis.localStorage?.getItem(`onethu.tab-layout.${key}.v1`);
+    stored = raw ? (JSON.parse(raw) as Partial<TabLayout>) : null;
+  } catch {
+    stored = null;
+  }
+  const known = new Set(allIds);
+  const order = (Array.isArray(stored?.order) ? stored.order : [])
+    .filter((id) => known.delete(id)); // 去重 + 只留已知
+  order.push(...allIds.filter((id) => known.has(id))); // 新栏目 / 缺项按默认序补尾
+  const hidden = (Array.isArray(stored?.hidden) ? stored.hidden : []).filter((id) => allIds.includes(id));
+  return { order, hidden };
+}
+
+export function saveTabLayout(key: string, layout: TabLayout): void {
+  try {
+    globalThis.localStorage?.setItem(`onethu.tab-layout.${key}.v1`, JSON.stringify(layout));
+  } catch {
+    /* 存储不可用：会话内仍生效 */
+  }
+}

--- a/apps/desktop/src/pages/info/InfoPage.tsx
+++ b/apps/desktop/src/pages/info/InfoPage.tsx
@@ -13,9 +13,14 @@
  * 子栏直达（首页入口化）：navigate("info", { infoTab }) 指定 segmented 初始 tab，
  * 与 infoNewsId 同款消费模式（挂载初值 + navParams 身份触发的 effect）；页内切换
  * 不回写参数，缺省时保持原默认成绩 tab。
+ *
+ * 栏目管理（tabLayout）：栏目可选择隐藏 + ↑↓ 调序，localStorage 持久化；
+ * 当前 tab 被隐藏时回落到第一个可见栏目。
  */
 import { useEffect, useState } from "react";
-import { SegmentedOverflow, PageHead } from "../../components/Layout.js";
+import { Empty, PageHead, SegmentedOverflow } from "../../components/Layout.js";
+import { TabManageModal } from "../../components/TabManageModal.js";
+import { loadTabLayout, saveTabLayout, type TabLayout } from "../../lib/tabLayout.js";
 import { useApp } from "../../state/context.js";
 import { ExamsTab } from "./ExamsTab.js";
 import { NewsTab } from "./NewsTab.js";
@@ -36,6 +41,8 @@ const TABS: Array<{ id: InfoTab; label: string }> = [
   { id: "news", label: "新闻" },
   { id: "profile", label: "个人信息" },
 ];
+const TAB_IDS = TABS.map((t) => t.id);
+const DEFAULT_LAYOUT: TabLayout = { order: TAB_IDS, hidden: [] };
 
 export function InfoPage() {
   const { navParams } = useApp();
@@ -48,6 +55,18 @@ export function InfoPage() {
   const [visited, setVisited] = useState<ReadonlySet<InfoTab>>(
     () => new Set(navParams?.infoNewsId ? ["report", "news"] : [navParams?.infoTab ?? "report"]),
   );
+
+  /** 栏目布局（显隐 + 顺序） */
+  const [layout, setLayout] = useState<TabLayout>(() => loadTabLayout("info", TAB_IDS));
+  const [manageOpen, setManageOpen] = useState(false);
+  const applyLayout = (l: TabLayout) => {
+    setLayout(l);
+    saveTabLayout("info", l);
+  };
+  const labelOf = (id: InfoTab) => TABS.find((t) => t.id === id)?.label ?? id;
+  const visibleIds = layout.order.filter((id) => !layout.hidden.includes(id)) as InfoTab[];
+  /** 当前 tab 被隐藏 → 回落到第一个可见栏目（全部隐藏则保持 null 走空态） */
+  const effTab = visibleIds.includes(tab) ? tab : visibleIds[0];
 
   useEffect(() => {
     const params = navParams;
@@ -72,28 +91,51 @@ export function InfoPage() {
 
   return (
     <>
-      <PageHead title="信息" />
+      <PageHead
+        title="信息"
+        actions={
+          <button className="btn" onClick={() => setManageOpen(true)} title="栏目显隐与排序">
+            管理栏目
+          </button>
+        }
+      />
       <SegmentedOverflow ariaLabel="信息功能" style={{ marginBottom: 14 }}>
-        {TABS.map(({ id, label }) => (
+        {visibleIds.map((id) => (
           <button
             key={id}
             role="tab"
-            aria-selected={tab === id}
-            className={tab === id ? "is-active" : ""}
+            aria-selected={effTab === id}
+            className={effTab === id ? "is-active" : ""}
             onClick={() => activate(id)}
           >
-            {label}
+            {labelOf(id)}
           </button>
         ))}
       </SegmentedOverflow>
 
-      <div hidden={tab !== "report"}>{visited.has("report") ? <ReportTab /> : null}</div>
-      <div hidden={tab !== "fitness"}>{visited.has("fitness") ? <FitnessTab /> : null}</div>
-      <div hidden={tab !== "exams"}>{visited.has("exams") ? <ExamsTab /> : null}</div>
-      <div hidden={tab !== "evaluation"}>{visited.has("evaluation") ? <EvaluationTab /> : null}</div>
-      <div hidden={tab !== "calendar"}>{visited.has("calendar") ? <CalendarTab /> : null}</div>
-      <div hidden={tab !== "news"}>{visited.has("news") ? <NewsTab newsId={newsId} onConsumeNewsId={() => setNewsId(null)} /> : null}</div>
-      <div hidden={tab !== "profile"}>{visited.has("profile") ? <ProfileTab /> : null}</div>
+      {effTab === null ? (
+        <Empty text="所有栏目已隐藏，点击右上「管理栏目」恢复。" />
+      ) : (
+        <>
+          <div hidden={effTab !== "report"}>{visited.has("report") ? <ReportTab /> : null}</div>
+          <div hidden={effTab !== "fitness"}>{visited.has("fitness") ? <FitnessTab /> : null}</div>
+          <div hidden={effTab !== "exams"}>{visited.has("exams") ? <ExamsTab /> : null}</div>
+          <div hidden={effTab !== "evaluation"}>{visited.has("evaluation") ? <EvaluationTab /> : null}</div>
+          <div hidden={effTab !== "calendar"}>{visited.has("calendar") ? <CalendarTab /> : null}</div>
+          <div hidden={effTab !== "news"}>{visited.has("news") ? <NewsTab newsId={newsId} onConsumeNewsId={() => setNewsId(null)} /> : null}</div>
+          <div hidden={effTab !== "profile"}>{visited.has("profile") ? <ProfileTab /> : null}</div>
+        </>
+      )}
+
+      <TabManageModal
+        open={manageOpen}
+        onClose={() => setManageOpen(false)}
+        title="管理信息栏目"
+        tabs={TABS}
+        layout={layout}
+        onApply={applyLayout}
+        onReset={() => applyLayout(DEFAULT_LAYOUT)}
+      />
     </>
   );
 }

--- a/apps/desktop/src/pages/info/LifePage.tsx
+++ b/apps/desktop/src/pages/info/LifePage.tsx
@@ -10,9 +10,14 @@
  * 子栏直达（首页入口化）：navigate("life", { lifeTab }) 指定初始 tab（缺省宿舍），
  * 与 InfoPage 的 infoNewsId 同款消费模式（挂载初值 + navParams 身份触发的
  * effect）；页内切换不回写参数。
+ *
+ * 栏目管理（tabLayout）：栏目可选择隐藏 + ↑↓ 调序，localStorage 持久化；
+ * 当前 tab 被隐藏时回落到第一个可见栏目。
  */
 import { useEffect, useState } from "react";
-import { SegmentedOverflow, PageHead } from "../../components/Layout.js";
+import { Empty, PageHead, SegmentedOverflow } from "../../components/Layout.js";
+import { TabManageModal } from "../../components/TabManageModal.js";
+import { loadTabLayout, saveTabLayout, type TabLayout } from "../../lib/tabLayout.js";
 import { useApp } from "../../state/context.js";
 import { CardTab } from "./CardTab.js";
 import { DormTab } from "./DormTab.js";
@@ -37,12 +42,26 @@ const TABS: Array<{ id: LifeTab; label: string }> = [
   { id: "gradincome", label: "研究生收入" },
   { id: "network", label: "校园网" },
 ];
+const TAB_IDS = TABS.map((t) => t.id);
+const DEFAULT_LAYOUT: TabLayout = { order: TAB_IDS, hidden: [] };
 
 export function LifePage() {
   const { navParams } = useApp();
   const [tab, setTab] = useState<LifeTab>(() => navParams?.lifeTab ?? "dorm");
   /** 已激活过的 tab 保持挂载：切回即显（数据在 hook 里，无需重复请求） */
   const [visited, setVisited] = useState<ReadonlySet<LifeTab>>(() => new Set([navParams?.lifeTab ?? "dorm"]));
+
+  /** 栏目布局（显隐 + 顺序） */
+  const [layout, setLayout] = useState<TabLayout>(() => loadTabLayout("life", TAB_IDS));
+  const [manageOpen, setManageOpen] = useState(false);
+  const applyLayout = (l: TabLayout) => {
+    setLayout(l);
+    saveTabLayout("life", l);
+  };
+  const labelOf = (id: LifeTab) => TABS.find((t) => t.id === id)?.label ?? id;
+  const visibleIds = layout.order.filter((id) => !layout.hidden.includes(id)) as LifeTab[];
+  /** 当前 tab 被隐藏 → 回落到第一个可见栏目（全部隐藏则保持 null 走空态） */
+  const effTab = visibleIds.includes(tab) ? tab : visibleIds[0];
 
   useEffect(() => {
     const direct = navParams?.lifeTab;
@@ -58,30 +77,53 @@ export function LifePage() {
 
   return (
     <>
-      <PageHead title="生活" />
+      <PageHead
+        title="生活"
+        actions={
+          <button className="btn" onClick={() => setManageOpen(true)} title="栏目显隐与排序">
+            管理栏目
+          </button>
+        }
+      />
       <SegmentedOverflow ariaLabel="生活功能" style={{ marginBottom: 14 }}>
-        {TABS.map(({ id, label }) => (
+        {visibleIds.map((id) => (
           <button
             key={id}
             role="tab"
-            aria-selected={tab === id}
-            className={tab === id ? "is-active" : ""}
+            aria-selected={effTab === id}
+            className={effTab === id ? "is-active" : ""}
             onClick={() => activate(id)}
           >
-            {label}
+            {labelOf(id)}
           </button>
         ))}
       </SegmentedOverflow>
 
-      {/* 模块头由栏目名与各 tab 内部分区标题承担（WasherTab 自带「洗衣机」头） */}
-      <div hidden={tab !== "dorm"}>{visited.has("dorm") ? <DormTab /> : null}</div>
-      <div hidden={tab !== "washer"}>{visited.has("washer") ? <WasherTab /> : null}</div>
-      <div hidden={tab !== "hygiene"}>{visited.has("hygiene") ? <HygieneTab /> : null}</div>
-      <div hidden={tab !== "card"}>{visited.has("card") ? <CardTab /> : null}</div>
-      <div hidden={tab !== "invoice"}>{visited.has("invoice") ? <InvoiceTab /> : null}</div>
-      <div hidden={tab !== "payroll"}>{visited.has("payroll") ? <PayrollTab /> : null}</div>
-      <div hidden={tab !== "gradincome"}>{visited.has("gradincome") ? <GradIncomeTab /> : null}</div>
-      <div hidden={tab !== "network"}>{visited.has("network") ? <NetworkTab /> : null}</div>
+      {effTab === null ? (
+        <Empty text="所有栏目已隐藏，点击右上「管理栏目」恢复。" />
+      ) : (
+        <>
+          {/* 模块头由栏目名与各 tab 内部分区标题承担（WasherTab 自带「洗衣机」头） */}
+          <div hidden={effTab !== "dorm"}>{visited.has("dorm") ? <DormTab /> : null}</div>
+          <div hidden={effTab !== "washer"}>{visited.has("washer") ? <WasherTab /> : null}</div>
+          <div hidden={effTab !== "hygiene"}>{visited.has("hygiene") ? <HygieneTab /> : null}</div>
+          <div hidden={effTab !== "card"}>{visited.has("card") ? <CardTab /> : null}</div>
+          <div hidden={effTab !== "invoice"}>{visited.has("invoice") ? <InvoiceTab /> : null}</div>
+          <div hidden={effTab !== "payroll"}>{visited.has("payroll") ? <PayrollTab /> : null}</div>
+          <div hidden={effTab !== "gradincome"}>{visited.has("gradincome") ? <GradIncomeTab /> : null}</div>
+          <div hidden={effTab !== "network"}>{visited.has("network") ? <NetworkTab /> : null}</div>
+        </>
+      )}
+
+      <TabManageModal
+        open={manageOpen}
+        onClose={() => setManageOpen(false)}
+        title="管理生活栏目"
+        tabs={TABS}
+        layout={layout}
+        onApply={applyLayout}
+        onReset={() => applyLayout(DEFAULT_LAYOUT)}
+      />
     </>
   );
 }


### PR DESCRIPTION
Closes #14

## 改动

### 新增
- `lib/tabLayout.ts`：栏目布局（`order` + `hidden`）localStorage 持久化，按页分键（`onethu.tab-layout.<page>.v1`）。合并规则只记增量：存储里只存已知 id 的排列与隐藏集，新增栏目默认可见、按默认序补尾——**升级不丢用户配置**
- `components/TabManageModal.tsx`：通用栏目管理弹窗——勾选显隐、↑↓ 调序、恢复默认，操作**即时生效**（无需点保存）

### 接入
- `InfoPage`（信息 7 栏）与 `LifePage`（生活 8 栏）：页头「管理栏目」按钮；segmented 按布局顺序只渲染可见栏目
- 边界：当前栏目被隐藏 → 自动回落到第一个可见栏目；全部隐藏 → 空态提示引导恢复；首页入口直达被隐藏栏目时同样回落

## 验证

- ✅ `tsc --noEmit` 通过
- ✅ `vite build` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)