### PR TITLE
fix(transport): webvpn 单向降级加回切机制——登录前直连探活 + 对称反向降级

### DIFF
--- a/apps/desktop/src/lib/clients.ts
+++ b/apps/desktop/src/lib/clients.ts
@@ -202,7 +202,15 @@ export async function login(
   pendingSecret = { username, password, remember };
   if (!remember) await clearRemembered().catch(() => undefined);
 
-  const savedMode = globalThis.localStorage?.getItem(TRANSPORT_KEY) ?? "direct";
+  let savedMode = globalThis.localStorage?.getItem(TRANSPORT_KEY) ?? "direct";
+  // 回切探测（#4）：持久化的 webvpn 模式没有回切机制，回校园网后仍全量绕道
+  // webvpn → 会话互踢死循环。登录前探测内网专属 host（usereg 公网不可达），
+  // 可达 = 在校园网 → 本次直接走 direct 并清掉持久化降级标记。
+  if (savedMode === "webvpn" && (await directReachable())) {
+    globalThis.localStorage?.removeItem(TRANSPORT_KEY);
+    savedMode = "direct";
+    await logLine("TRANSPORT webvpn→direct 回切：直连可达（在校园网），不再绕道 WebVPN");
+  }
   try {
     const result = await attempt(username, password, savedMode === "webvpn");
     if (result.state === "ready") {
@@ -219,9 +227,40 @@ export async function login(
       if (result.state === "ready") await persist();
       return result;
     }
+    // 对称反向降级（#4）：webvpn 链路网络错误 → 试一次 direct，成功则回切
+    if (savedMode === "webvpn" && isNetworkError(err)) {
+      http.jar.clear();
+      try {
+        const result = await attempt(username, password, false);
+        globalThis.localStorage?.removeItem(TRANSPORT_KEY);
+        await logLine("TRANSPORT webvpn→direct 反向降级：webvpn 网络错误，直连重试成功");
+        if (result.state === "ready") await persist();
+        return result;
+      } catch {
+        /* direct 也不通：落回原错误 */
+      }
+    }
     if (err instanceof Error) await dumpDebug(err);
     await logLine("LOGIN-ERR\n" + session.debugLog.join("\n"));
     throw err;
+  }
+}
+
+/**
+ * 直连可达性探测（#4 回切判据）：取内网专属 host（usereg 仅校园网内可直连，
+ * 公网/WebVPN 场景必然超时），no-cors 只关心连接成败，不读响应。
+ * 系统代理（TUN/全局）下探测包也会进代理：代理转发不了内网 → 判不可达 →
+ * 维持 webvpn，宁可保守不误切。
+ */
+async function directReachable(): Promise<boolean> {
+  try {
+    await fetch("https://usereg.tsinghua.edu.cn/", {
+      mode: "no-cors",
+      signal: AbortSignal.timeout(2500),
+    });
+    return true;
+  } catch {
+    return false;
   }
 }
 


### PR DESCRIPTION
Closes #4

## 问题回顾

校外首次直连失败后 `setItem(transport="webvpn")` **永久生效、无回切机制**（`clients.ts`）。回校园网后所有流量仍绕道 WebVPN，与直连会话互踢，形成每分钟数百跳的登录死循环，并连带踢掉电子身份原生窗口的会话（#3 现场叠加）。

## 修复（对应 issue 建议一、二）

### ① 登录前直连探活回切
`savedMode === "webvpn"` 时，登录前先探测**内网专属 host**（`usereg.tsinghua.edu.cn`，公网不可达）：
- 可达 = 在校园网 → 本次直接走 direct，并 `removeItem(TRANSPORT_KEY)` 清除持久化降级标记（真正回切）
- 不可达 → 维持 webvpn（校外场景不变）

`fetch(..., { mode: "no-cors", signal: AbortSignal.timeout(2500) })`，只判连接成败不读响应。

### ② 对称反向降级
webvpn 链路登录遇到**网络错误** → 试一次 direct，成功则同样清除标记回切（与既有 direct→webvpn 降级对称）。

### ③ 日志
回切/反向降级均落 `TRANSPORT webvpn→direct ...` 日志行，可在 onethu-debug.log 追溯。

## 设计取舍

- 探测 host 选 **usereg** 而非 issue 里举例的 id.tsinghua.edu.cn：后者公网可达，校外探活会误判「可直连」；usereg 仅校园网内可直连，判据可靠
- 系统代理（TUN/全局）下探测包也进代理：代理转发不了内网 → 判不可达 → **保守维持 webvpn 不误切**；挂梯子的场景建议配合 #2 的 no_proxy 使用

## 验证

- ✅ `tsc --noEmit` 通过
- ✅ `vite build` 通过
- 桌面端登录/重启链路需校园网+校外双环境实测（本地检视版已并入此修复）

🤖 Generated with [Claude Code](https://claude.com/claude-code)