### PR TITLE
feat(info): 课程信息模块——接入 courseX 课程共享计划，免凭证查询全校开课时间地点

### DIFF
--- a/apps/desktop/src/lib/coursex.ts
+++ b/apps/desktop/src/lib/coursex.ts
@@ -1,0 +1,48 @@
+/**
+ * 课程共享计划（courseX / tsinghua.app）桌面端配置与会话。
+ *
+ * refresh token 由用户在 tsinghua.app 网站登录后从浏览器 cookie
+ * （__Host-refresh_token）复制、在设置页粘贴；accessToken 只在内存
+ * （core CourseXSession），不落盘。存储口径与 onethu.custom-courses.v1
+ * 等 localStorage 配置一致。
+ */
+import { CourseXSession } from "@onethu/core";
+import { universalFetch } from "./transport.js";
+
+const KEY = "onethu.coursex.v1";
+
+export interface CourseXConfig {
+  refreshToken: string;
+  /** 登录网络学堂后自动共享本学期课程（二期开关，一期手动触发） */
+  autoShare: boolean;
+  /** 上次手动/自动共享成功的时间与行数（设置页状态展示） */
+  lastSharedAt?: number;
+  lastSharedCount?: number;
+}
+
+export function loadCourseXConfig(): CourseXConfig | null {
+  try {
+    const raw = JSON.parse(localStorage.getItem(KEY) ?? "null") as Partial<CourseXConfig> | null;
+    if (!raw || typeof raw.refreshToken !== "string" || !raw.refreshToken) return null;
+    return { refreshToken: raw.refreshToken, autoShare: raw.autoShare === true };
+  } catch {
+    return null;
+  }
+}
+
+export function saveCourseXConfig(cfg: CourseXConfig | null): void {
+  if (!cfg) localStorage.removeItem(KEY);
+  else localStorage.setItem(KEY, JSON.stringify(cfg));
+}
+
+/** 会话单例：随 refreshToken 变化重建（token 更新后旧会话自然作废） */
+let sessionSingleton: { token: string; session: CourseXSession } | null = null;
+
+export function getCourseXSession(refreshToken?: string): CourseXSession | null {
+  const token = refreshToken ?? loadCourseXConfig()?.refreshToken;
+  if (!token) return null;
+  if (!sessionSingleton || sessionSingleton.token !== token) {
+    sessionSingleton = { token, session: new CourseXSession(universalFetch, token) };
+  }
+  return sessionSingleton.session;
+}

--- a/apps/desktop/src/pages/Settings.tsx
+++ b/apps/desktop/src/pages/Settings.tsx
@@ -3,8 +3,11 @@ import { useEffect, useState } from "react";
 import { Card, PageHead, SectionHead } from "../components/Layout.js";
 import { invoke } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { clearRemembered, loadRemembered, session } from "../lib/clients.js";
+import { uploadCoursesToCourseX } from "@onethu/core";
+import { clearRemembered, learn, loadRemembered, logLine, session } from "../lib/clients.js";
 import { clearHomeLayout } from "../lib/homeCards.js";
+import { getCourseXSession, loadCourseXConfig, saveCourseXConfig } from "../lib/coursex.js";
+import { universalFetch } from "../lib/transport.js";
 import { useApp } from "../state/context.js";
 
 export function SettingsPage() {
@@ -14,6 +17,13 @@ export function SettingsPage() {
   // 首页布局恢复：点击后短暂显示「已恢复默认」，到点回位
   const [homeResetAt, setHomeResetAt] = useState(0);
   const [eidMsg, setEidMsg] = useState<string | null>(null);
+
+  /* —— 课程共享计划（courseX）—— */
+  const [cxConfig, setCxConfig] = useState(() => loadCourseXConfig());
+  const [cxInput, setCxInput] = useState("");
+  const [cxMsg, setCxMsg] = useState<string | null>(null);
+  const [cxTesting, setCxTesting] = useState(false);
+  const [cxSharing, setCxSharing] = useState(false);
 
   useEffect(() => {
     void loadRemembered().then((r) => setHasSaved(!!r));
@@ -32,6 +42,65 @@ export function SettingsPage() {
       setHasSaved(false);
     } finally {
       setClearing(false);
+    }
+  };
+
+  /** 保存并测试连接：换 accessToken 成功即视为凭证有效 */
+  const onCxSave = async () => {
+    const token = cxInput.trim();
+    if (!token) return;
+    setCxTesting(true);
+    setCxMsg(null);
+    try {
+      const s = getCourseXSession(token);
+      await s!.getAccessToken(true);
+      const cfg = { refreshToken: token, autoShare: cxConfig?.autoShare ?? false };
+      saveCourseXConfig(cfg);
+      setCxConfig(cfg);
+      setCxInput("");
+      setCxMsg("连接成功，课程信息页即可查询全校开课的上课地点。");
+    } catch (err) {
+      void logLine("PAGE-ERR COURSEX-SAVE " + (err instanceof Error ? err.message : String(err))).catch(() => undefined);
+      setCxMsg(`连接失败：${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setCxTesting(false);
+    }
+  };
+
+  /** 立即共享本学期课程：网络学堂课程列表 + 时间地点 → courseX 共享库 */
+  const onCxShare = async () => {
+    const s = getCourseXSession();
+    if (!s) return;
+    setCxSharing(true);
+    setCxMsg(null);
+    try {
+      const semester = await learn.getCurrentSemester();
+      const courses = await learn.getCourseListForSharing(semester.id);
+      const n = await uploadCoursesToCourseX(
+        universalFetch,
+        s,
+        courses.map((c) => ({
+          id: c.id,
+          name: c.name,
+          englishName: c.englishName || undefined,
+          // 教师号（jsh）缺失时 core 自动省略 teacher 嵌套对象
+          teacherId: c.teacherNumber || undefined,
+          teacherName: c.teacherName,
+          timeLocation: c.timeAndLocation,
+          semesterId: semester.id,
+          number: c.courseNumber,
+          index: c.courseIndex,
+        })),
+      );
+      const cfg = { ...(cxConfig ?? { refreshToken: s.refreshToken, autoShare: false }), lastSharedAt: Date.now(), lastSharedCount: n };
+      saveCourseXConfig(cfg);
+      setCxConfig(cfg);
+      setCxMsg(`已共享本学期 ${courses.length} 门课程（影响 ${n} 行）——感谢回馈共享库！`);
+    } catch (err) {
+      void logLine("PAGE-ERR COURSEX-SHARE " + (err instanceof Error ? err.message : String(err))).catch(() => undefined);
+      setCxMsg(`共享失败：${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setCxSharing(false);
     }
   };
 
@@ -118,6 +187,76 @@ export function SettingsPage() {
             {homeResetAt ? "已恢复默认" : "恢复默认布局"}
           </button>
         </div>
+      </Card>
+
+      <SectionHead title="课程共享计划" />
+      <Card>
+        <div className="setting-row" style={{ alignItems: "flex-start" }}>
+          <div style={{ flex: 1 }}>
+            <div className="setting-title">共享回馈（可选）· 连接 courseX</div>
+            <div className="setting-desc">
+              「信息 → 课程信息」的查询走公开网页，无需任何配置；只有把自己的课程
+              时间地点上传回馈共享库时才需要连接。在浏览器注册并登录 tsinghua.app，
+              开发者工具（F12）→ Application → Cookies 复制 __Host-refresh_token 的值粘贴到此处。
+              {cxConfig
+                ? cxConfig.lastSharedAt
+                  ? ` 已连接 · 上次共享 ${new Date(cxConfig.lastSharedAt).toLocaleString()}（${cxConfig.lastSharedCount ?? 0} 行）。`
+                  : " 已连接。"
+                : " 当前未连接（不影响查询，仅不能上传回馈）。"}
+            </div>
+            {cxMsg ? (
+              <div style={{ marginTop: 8, fontSize: 13, color: "var(--text-2)" }}>{cxMsg}</div>
+            ) : null}
+            {cxConfig ? null : (
+              <div style={{ display: "flex", gap: 8, marginTop: 10, maxWidth: 420 }}>
+                <input
+                  className="input"
+                  type="password"
+                  style={{ flex: 1 }}
+                  value={cxInput}
+                  onChange={(e) => setCxInput(e.target.value)}
+                  placeholder="粘贴 __Host-refresh_token"
+                  aria-label="courseX refresh token"
+                />
+                <button className="btn" disabled={cxTesting || !cxInput.trim()} onClick={() => void onCxSave()}>
+                  {cxTesting ? "测试中…" : "保存并测试"}
+                </button>
+              </div>
+            )}
+          </div>
+          {cxConfig ? (
+            <div style={{ display: "flex", gap: 8 }}>
+              <button className="btn" disabled={cxSharing} onClick={() => void onCxShare()}>
+                {cxSharing ? "共享中…" : "立即共享本学期课程"}
+              </button>
+              <button
+                className="btn"
+                disabled={cxTesting}
+                onClick={() => {
+                  saveCourseXConfig(null);
+                  setCxConfig(null);
+                  setCxMsg("已断开连接（本地凭证已清除）。");
+                }}
+              >
+                断开
+              </button>
+            </div>
+          ) : null}
+        </div>
+        {cxConfig ? (
+          <div className="setting-row">
+            <div>
+              <div className="setting-title">共享说明</div>
+              <div className="setting-desc">
+                「立即共享」会上传本学期课程的时间地点（课号、课序、课名、教师、上课时间地点），
+                不包含任何个人信息——与 learnX 官方口径一致。共享后全校用户都能查到这些课在哪里上。
+              </div>
+            </div>
+            <button className="btn btn-ghost" onClick={() => void openUrl("https://tsinghua.app/courses")}>
+              访问 courseX
+            </button>
+          </div>
+        ) : null}
       </Card>
 
       <SectionHead title="安全" />

--- a/apps/desktop/src/pages/info/CourseInfoTab.tsx
+++ b/apps/desktop/src/pages/info/CourseInfoTab.tsx
@@ -1,0 +1,220 @@
+/**
+ * 课程信息 —— courseX 课程信息共享计划（tsinghua.app / 星期四）查询页。
+ * 众包共享库：全校用户把自己网络学堂课程的时间地点共享出来，这里按
+ * 课程名/教师搜索任意开课并查看上课时间与地点。
+ *
+ * 查询走 tsinghua.app 公开网页（服务端渲染，免凭证——与浏览器直接搜
+ * 等价）；refresh token 仅在「设置 → 课程共享计划」连接后用于上传
+ * 回馈。数据为第三方众包，覆盖不全时诚实提示，不造数据。
+ */
+import { Fragment, useCallback, useEffect, useState } from "react";
+import type { CourseXDetail, CourseXSemester, CourseXSummary } from "@onethu/core";
+import {
+  courseXSemesterText,
+  getCourseXDetailPublic,
+  getCourseXSemesters,
+  searchCourseXPublic,
+} from "@onethu/core";
+import { Card, SectionHead, SkeletonRows } from "../../components/Layout.js";
+import { IconSearch } from "../../components/Icons.js";
+import { SearchSelect } from "../../components/SearchSelect.jsx";
+import { useApp } from "../../state/context.js";
+import { universalFetch } from "../../lib/transport.js";
+import { TabEmpty, TabError, logTabErr, tabErrorText } from "./tabStates.js";
+
+type SearchState = "idle" | "loading" | "error" | "ready";
+
+/** 行展开详情（一次只展开一行） */
+interface DetailState {
+  key: string;
+  loading: boolean;
+  data: CourseXDetail | null;
+  error: string | null;
+}
+
+export function CourseInfoTab() {
+  const { status } = useApp();
+
+  const [input, setInput] = useState("");
+  const [semesters, setSemesters] = useState<CourseXSemester[] | null>(null);
+  const [semester, setSemester] = useState<string>("");
+  const [courses, setCourses] = useState<CourseXSummary[] | null>(null);
+  const [state, setState] = useState<SearchState>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [detail, setDetail] = useState<DetailState | null>(null);
+
+  /** 学期列表（挂载即拉，默认当前学期——与 courseX 网页一致的交互） */
+  useEffect(() => {
+    if (status !== "ready") return;
+    getCourseXSemesters(universalFetch)
+      .then((list) => {
+        if (list.length > 0) {
+          setSemesters(list);
+          setSemester(list.find((s) => s.current)?.id ?? list[0]!.id);
+        }
+      })
+      .catch((err: unknown) => logTabErr("COURSEX-SEMESTERS", err));
+  }, [status]);
+
+  const runSearch = useCallback(
+    async (q: string, semOverride?: string) => {
+      if (!q.trim()) return;
+      setState("loading");
+      setError(null);
+      setDetail(null);
+      try {
+        const sem = semOverride ?? semester;
+        setCourses(await searchCourseXPublic(universalFetch, q.trim(), sem || undefined));
+        setState("ready");
+      } catch (err) {
+        logTabErr("COURSEX-SEARCH", err);
+        setError(tabErrorText(err));
+        setState("error");
+      }
+    },
+    [semester],
+  );
+
+  const openDetail = useCallback(async (c: CourseXSummary) => {
+    // 再点同一行 = 收起
+    setDetail((d) => (d?.key === c.id ? null : { key: c.id, loading: true, data: null, error: null }));
+    try {
+      const data = await getCourseXDetailPublic(universalFetch, c.id);
+      setDetail({ key: c.id, loading: false, data, error: null });
+    } catch (err) {
+      logTabErr("COURSEX-DETAIL", err);
+      setDetail({ key: c.id, loading: false, data: null, error: tabErrorText(err) });
+    }
+  }, []);
+
+  if (status === "demo") {
+    return <TabEmpty text="演示模式不提供课程共享查询，登录后可搜索全校开课的上课地点。" />;
+  }
+
+  return (
+    <>
+      <SectionHead
+        title="课程信息"
+        aside="课程共享计划 · courseX · 众包数据，覆盖不全时请多包涵"
+      />
+
+      <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+        {semesters && semesters.length > 0 ? (
+          <SearchSelect
+            value={semester}
+            onChange={(v) => {
+              setSemester(v);
+              // 已有搜索词时切学期立即重查（与 courseX 网页同款交互）
+              if (input.trim()) void runSearch(input, v);
+            }}
+            placeholder="选择学期…"
+            options={semesters.map((s) => ({ value: s.id, label: s.label }))}
+          />
+        ) : null}
+        <div className="search-box" style={{ flex: 1, minWidth: 160 }}>
+          <IconSearch width={15} height={15} />
+          <input
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void runSearch(input);
+            }}
+            placeholder="搜索课程名 / 教师姓名（如：微积分 / 冯铃）"
+            aria-label="搜索课程"
+          />
+          {input ? (
+            <button className="btn btn-ghost" onClick={() => setInput("")}>
+              清除
+            </button>
+          ) : null}
+        </div>
+        <button className="btn" disabled={state === "loading"} onClick={() => void runSearch(input)}>
+          搜索
+        </button>
+      </div>
+
+      {state === "error" ? (
+        <TabError unavailable={false} text={error} onRetry={() => void runSearch(input)} />
+      ) : null}
+
+      {state === "loading" ? (
+        <SkeletonRows rows={6} />
+      ) : state === "ready" ? (
+        (courses?.length ?? 0) === 0 ? (
+          <TabEmpty text="共享库中未找到匹配的课程——换个关键词试试，或该课尚未被共享（覆盖取决于大家的参与）。" />
+        ) : (
+          <>
+            <SectionHead title="搜索结果" aside={`共 ${courses!.length} 条 · 点行查看时间地点`} />
+            <Card style={{ padding: 0, overflow: "auto" }}>
+              <table className="data-table">
+                <thead>
+                  <tr>
+                    <th>课程</th>
+                    <th>教师</th>
+                    <th>学期</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {courses!.map((c, i) => (
+                    <Fragment key={c.id}>
+                      <tr
+                        style={{ animationDelay: `${Math.min(i, 12) * 25}ms`, cursor: "pointer" }}
+                        onClick={() => void openDetail(c)}
+                      >
+                        <td className="cell-title">
+                          {c.name}
+                          {c.englishName ? (
+                            <span style={{ opacity: 0.55, marginLeft: 6, fontSize: 12 }}>{c.englishName}</span>
+                          ) : null}
+                        </td>
+                        <td>{c.teacherName || "—"}</td>
+                        <td style={{ whiteSpace: "nowrap" }}>{courseXSemesterText(c.semesterId)}</td>
+                      </tr>
+                      {detail?.key === c.id ? (
+                        <tr>
+                          <td colSpan={3} style={{ background: "rgba(0,0,0,0.02)" }}>
+                            {detail.loading ? (
+                              <span style={{ opacity: 0.6 }}>正在加载时间地点…</span>
+                            ) : detail.error ? (
+                              <span style={{ color: "var(--red)" }}>{detail.error}</span>
+                            ) : detail.data ? (
+                              <div style={{ display: "flex", flexDirection: "column", gap: 6, padding: "4px 0" }}>
+                                <div style={{ display: "flex", gap: 6, flexWrap: "wrap", alignItems: "baseline" }}>
+                                  <span style={{ fontWeight: 600 }}>{detail.data.name}</span>
+                                  {detail.data.teacherName ? (
+                                    <span style={{ opacity: 0.7 }}>{detail.data.teacherName}</span>
+                                  ) : null}
+                                  {detail.data.semesterId ? (
+                                    <span className="chip chip-gray">{detail.data.semesterId}</span>
+                                  ) : null}
+                                </div>
+                                {detail.data.timeLocation.length > 0 ? (
+                                  detail.data.timeLocation.map((t, ti) => (
+                                    <div key={ti} style={{ display: "flex", gap: 8, alignItems: "baseline" }}>
+                                      <span className="chip chip-green">时间地点</span>
+                                      <span>{t}</span>
+                                    </div>
+                                  ))
+                                ) : (
+                                  <span style={{ opacity: 0.6 }}>
+                                    共享库暂无该课的时间地点——若你选了这门课，可在设置里「立即共享本学期课程」回馈数据。
+                                  </span>
+                                )}
+                              </div>
+                            ) : (
+                              <span style={{ opacity: 0.6 }}>共享库中无此课程详情。</span>
+                            )}
+                          </td>
+                        </tr>
+                      ) : null}
+                    </Fragment>
+                  ))}
+                </tbody>
+              </table>
+            </Card>
+          </>
+        )
+      ) : null}
+    </>
+  );
+}

--- a/apps/desktop/src/pages/info/InfoPage.tsx
+++ b/apps/desktop/src/pages/info/InfoPage.tsx
@@ -29,8 +29,9 @@ import { ReportTab } from "./ReportTab.js";
 import { FitnessTab } from "./FitnessTab.js";
 import { EvaluationTab } from "./EvaluationTab.js";
 import { CalendarTab } from "./CalendarTab.js";
+import { CourseInfoTab } from "./CourseInfoTab.js";
 
-export type InfoTab = "report" | "fitness" | "exams" | "evaluation" | "calendar" | "news" | "profile";
+export type InfoTab = "report" | "fitness" | "exams" | "evaluation" | "calendar" | "news" | "profile" | "courseinfo";
 
 const TABS: Array<{ id: InfoTab; label: string }> = [
   { id: "report", label: "成绩" },
@@ -40,6 +41,7 @@ const TABS: Array<{ id: InfoTab; label: string }> = [
   { id: "calendar", label: "校历" },
   { id: "news", label: "新闻" },
   { id: "profile", label: "个人信息" },
+  { id: "courseinfo", label: "课程信息" },
 ];
 const TAB_IDS = TABS.map((t) => t.id);
 const DEFAULT_LAYOUT: TabLayout = { order: TAB_IDS, hidden: [] };
@@ -124,6 +126,7 @@ export function InfoPage() {
           <div hidden={effTab !== "calendar"}>{visited.has("calendar") ? <CalendarTab /> : null}</div>
           <div hidden={effTab !== "news"}>{visited.has("news") ? <NewsTab newsId={newsId} onConsumeNewsId={() => setNewsId(null)} /> : null}</div>
           <div hidden={effTab !== "profile"}>{visited.has("profile") ? <ProfileTab /> : null}</div>
+          <div hidden={effTab !== "courseinfo"}>{visited.has("courseinfo") ? <CourseInfoTab /> : null}</div>
         </>
       )}
 

--- a/packages/core/src/coursex/client.ts
+++ b/packages/core/src/coursex/client.ts
@@ -1,0 +1,451 @@
+/**
+ * courseX 课程信息共享计划客户端（tsinghua.app / 星期四 Thursday）。
+ *
+ * courseX 的课程时间地点数据来自众包共享：learnX 用户授权后将自己网络学堂
+ * 已选课程的时间地点（v_wlkc_xk_sjddb）上传至共享库，全校用户合起来覆盖
+ * 全部开课。接口结论验证自 robertying/tsinghua.app-web（api/course.ts）与
+ * learnX（src/helpers/coursex.ts）开源实现：
+ *
+ * - GraphQL：POST https://api.tsinghua.app/v1/graphql（匿名无任何权限，须
+ *   Bearer accessToken）
+ * - 换 token：POST https://tsinghua.app/api/auth/session {refreshToken}
+ *   → { accessToken, expireAt }（秒级时间戳）
+ * - 搜索：course(name/teacher.name _ilike %q%)，详情含 time_location（JSON
+ *   字符串数组）与 course_reviews 均分
+ * - 上传：insert_course(on_conflict course_pkey → 更新 time_location)
+ *
+ * courseX 为第三方公开服务，无需校内会话，不走 HttpClient（避免被 WebVPN
+ * 包装）——与 washer/water 同款 FetchLike 直连。
+ */
+import type { FetchLike } from "../http.js";
+
+const SITE = "https://tsinghua.app";
+const GRAPHQL = "https://api.tsinghua.app/v1/graphql";
+
+export interface CourseXSummary {
+  id: string;
+  name: string;
+  englishName?: string;
+  teacherName: string;
+  semesterId: string;
+}
+
+export interface CourseXDetail {
+  id: string;
+  name: string;
+  englishName?: string;
+  teacherName: string;
+  semesterId: string;
+  /** 时间地点条目（如「星期五第3节 六教6B206」）；库中缺失为空数组 */
+  timeLocation: string[];
+  reviewAvg: number | null;
+  reviewCount: number;
+}
+
+/** 上传对象：字段与 learnX uploadCourses 一一对应（id = 网络学堂课程 id）。
+ *  teacherId/teacherName 可选：网络学堂列表接口偶尔不回传教师号（jsh），
+ *  缺号时不嵌套 teacher 对象，避免 teacher_pkey 空主键。 */
+export interface CourseXUploadCourse {
+  id: string;
+  name: string;
+  englishName?: string;
+  teacherId?: string;
+  teacherName?: string;
+  timeLocation: string[];
+  semesterId: string;
+  number: string;
+  index: number;
+}
+
+export class CourseXAuthError extends Error {
+  constructor(message = "课程共享计划凭证无效或已过期，请更新 refresh token") {
+    super(message);
+  }
+}
+
+/* ── 换 token（learnX 同款：POST /api/auth/session {refreshToken}） ── */
+
+interface SessionResponse {
+  accessToken?: string;
+  expireAt?: number;
+}
+
+export async function fetchCourseXAccessToken(
+  fetchLike: FetchLike,
+  refreshToken: string,
+): Promise<{ accessToken: string; expireAt: number }> {
+  const res = await fetchLike(`${SITE}/api/auth/session`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ refreshToken }),
+  });
+  if (res.status === 401 || res.status === 422) throw new CourseXAuthError();
+  const text = await res.text();
+  let json: SessionResponse;
+  try {
+    json = JSON.parse(text) as SessionResponse;
+  } catch {
+    throw new Error(`课程共享计划服务响应异常（HTTP ${res.status}）`);
+  }
+  if (!json.accessToken) throw new CourseXAuthError();
+  return { accessToken: json.accessToken, expireAt: (json.expireAt ?? 0) * 1000 };
+}
+
+/**
+ * courseX 会话：内存缓存 accessToken，到期前 60 秒自动重换。
+ * refreshToken 由调用方持久化（桌面端凭证存储），此处只在内存持有 token。
+ */
+export class CourseXSession {
+  #fetchLike: FetchLike;
+  #refreshToken: string;
+  #token: string | null = null;
+  #expireAt = 0;
+
+  constructor(fetchLike: FetchLike, refreshToken: string) {
+    this.#fetchLike = fetchLike;
+    this.#refreshToken = refreshToken;
+  }
+
+  get refreshToken(): string {
+    return this.#refreshToken;
+  }
+
+  async getAccessToken(force = false): Promise<string> {
+    if (!force && this.#token && Date.now() < this.#expireAt - 60_000) {
+      return this.#token;
+    }
+    const { accessToken, expireAt } = await fetchCourseXAccessToken(
+      this.#fetchLike,
+      this.#refreshToken,
+    );
+    this.#token = accessToken;
+    this.#expireAt = expireAt || Date.now() + 10 * 60_000;
+    return accessToken;
+  }
+}
+
+/* ── GraphQL 基座 ── */
+
+interface GraphQLResponse<T> {
+  data?: T | null;
+  errors?: Array<{ message: string }>;
+}
+
+async function gql<T>(
+  fetchLike: FetchLike,
+  session: CourseXSession,
+  query: string,
+  variables: Record<string, unknown>,
+): Promise<T> {
+  const run = async (token: string): Promise<Response> =>
+    fetchLike(GRAPHQL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+  let res = await run(await session.getAccessToken());
+  if (res.status === 401) {
+    // token 失效自愈：强制重换一次
+    res = await run(await session.getAccessToken(true));
+  }
+  if (res.status === 401) throw new CourseXAuthError();
+  const text = await res.text();
+  let json: GraphQLResponse<T>;
+  try {
+    json = JSON.parse(text) as GraphQLResponse<T>;
+  } catch {
+    throw new Error(`课程共享计划服务响应异常（HTTP ${res.status}）`);
+  }
+  if (json.errors?.length) {
+    const msg = json.errors[0]?.message ?? "";
+    if (/jwt|authorization|token/i.test(msg)) throw new CourseXAuthError(msg);
+    throw new Error(`课程共享计划查询失败：${msg}`);
+  }
+  if (!json.data) throw new Error("课程共享计划查询失败：无数据");
+  return json.data;
+}
+
+/* ── 查询（tsinghua.app-web api/course.ts GET_COURSES / GET_COURSE 同款） ── */
+
+interface CourseRow {
+  id: string;
+  name: string;
+  semester_id: string;
+  teacher?: { name: string } | null;
+}
+
+const SEARCH_QUERY = `
+  query OneTHUSearchCourses($query: String!) {
+    course(
+      where: { _or: [{ name: { _ilike: $query } }, { teacher: { name: { _ilike: $query } } }] }
+      order_by: [{ semester_id: desc }, { updated_at: desc }]
+      limit: 100
+    ) {
+      id
+      name
+      semester_id
+      teacher { name }
+    }
+  }
+`;
+
+export async function searchCourseX(
+  fetchLike: FetchLike,
+  session: CourseXSession,
+  query: string,
+): Promise<CourseXSummary[]> {
+  const data = await gql<{ course: CourseRow[] }>(fetchLike, session, SEARCH_QUERY, {
+    query: `%${query}%`,
+  });
+  return data.course.map((c) => ({
+    id: c.id,
+    name: c.name,
+    teacherName: c.teacher?.name ?? "",
+    semesterId: c.semester_id,
+  }));
+}
+
+const DETAIL_QUERY = `
+  query OneTHUGetCourse($id: String!) {
+    course_by_pk(id: $id) {
+      id
+      name
+      englishName
+      semester_id
+      time_location
+      teacher { name }
+      course_reviews_aggregate {
+        aggregate {
+          count
+          avg { rating }
+        }
+      }
+    }
+  }
+`;
+
+function parseTimeLocation(raw: unknown): string[] {
+  if (typeof raw !== "string" || !raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed.filter((s): s is string => typeof s === "string");
+  } catch {
+    /* 空间非 JSON（脏数据）按无地点处理 */
+  }
+  return [];
+}
+
+export async function getCourseXDetail(
+  fetchLike: FetchLike,
+  session: CourseXSession,
+  id: string,
+): Promise<CourseXDetail | null> {
+  const data = await gql<{
+    course_by_pk: ({
+      englishName?: string | null;
+      time_location?: string | null;
+      course_reviews_aggregate?: {
+        aggregate?: { count?: number; avg?: { rating?: number | null } | null } | null;
+      } | null;
+    } & CourseRow) | null;
+  }>(fetchLike, session, DETAIL_QUERY, { id });
+  const c = data.course_by_pk;
+  if (!c) return null;
+  const agg = c.course_reviews_aggregate?.aggregate;
+  return {
+    id: c.id,
+    name: c.name,
+    englishName: c.englishName || undefined,
+    teacherName: c.teacher?.name ?? "",
+    semesterId: c.semester_id,
+    timeLocation: parseTimeLocation(c.time_location),
+    reviewAvg: agg?.avg?.rating ?? null,
+    reviewCount: agg?.count ?? 0,
+  };
+}
+
+/* ── 上传（learnX coursex.ts insert_course 同款，回馈共享库） ── */
+
+const UPLOAD_MUTATION = `
+  mutation OneTHUAddCourses($objects: [course_insert_input!]!) {
+    insert_course(
+      objects: $objects
+      on_conflict: { constraint: course_pkey, update_columns: ["time_location", "name", "englishName"] }
+    ) {
+      affected_rows
+    }
+  }
+`;
+
+/** 上传本学期课程的时间地点；返回受影响行数。权限不足时服务端报错原样抛出。 */
+export async function uploadCoursesToCourseX(
+  fetchLike: FetchLike,
+  session: CourseXSession,
+  courses: CourseXUploadCourse[],
+): Promise<number> {
+  const objects = courses.map((c) => ({
+    id: c.id,
+    name: c.name,
+    englishName: c.englishName,
+    ...(c.teacherId
+      ? {
+          teacher: {
+            data: { id: c.teacherId, name: c.teacherName ?? "" },
+            on_conflict: { constraint: "teacher_pkey", update_columns: ["name"] },
+          },
+        }
+      : {}),
+    time_location: JSON.stringify(c.timeLocation),
+    semester_id: c.semesterId,
+    number: c.number,
+    index: c.index,
+  }));
+  const data = await gql<{ insert_course: { affected_rows: number } }>(
+    fetchLike,
+    session,
+    UPLOAD_MUTATION,
+    { objects },
+  );
+  return data.insert_course?.affected_rows ?? 0;
+}
+
+/* ── 学期文案（tsinghua.app-web lib/format getSemesterTextFromId 同义） ── */
+
+/** "2025-2026-1" → "2025-2026 学年秋季学期"；不认识的形态原样返回 */
+export function courseXSemesterText(id: string): string {
+  const m = /^(\d{4}-\d{4})-([123])$/.exec(id);
+  if (!m) return id;
+  const term = { "1": "秋季学期", "2": "春季学期", "3": "夏季学期" }[m[2] as "1" | "2" | "3"];
+  return `${m[1]} 学年${term}`;
+}
+
+/* ────────────────────────────────────────────────────────────────
+ * 免凭证公开查询：tsinghua.app 网页是服务端渲染（Next.js RSC 流），
+ * 搜索结果与课程详情（含时间地点）直接渲染在公开 HTML 里，浏览器
+ * 匿名可访问——GraphQL 才需要 token。OneTHU 查询一律走这条免 Key
+ * 路径；token 仅用于上传回馈。
+ *
+ * 实测页面形态（2026-09）：
+ * - GET /courses?q={关键词}   → <tbody><tr><td>教师</td><td>课名<br/>
+ *   <span…>英文名</span></td><td>…href="/courses/{学年-课程id}"…
+ * - GET /courses/{id}         → 流内 <div hidden id="S:N"><main…><div class=…card…>
+ *   <p>学期</p><p>课号-课序</p><h1>课名</h1><p>英文名</p><h2>教师</h2>
+ *   <ul><li>时间地点</li>…</ul>
+ * ──────────────────────────────────────────────────────────────── */
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .replace(/<[^>]*>/g, "")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#x27;|&#39;/g, "'")
+    .replace(/&nbsp;/g, " ")
+    .trim();
+}
+
+/** 请求头：必须用真实浏览器 UA——自定义 UA（如 Mozilla/5.0 (OneTHU)）实测被
+ *  服务端拦截返回空结果页（2026-09 实测 19 行 → 0 行）。 */
+const BROWSER_HEADERS = {
+  "User-Agent":
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36",
+};
+
+/** 免 Key 学期列表：解析 /courses 首页 <select id="semester-select">，
+ *  selected 项即当前学期（列表第一项）。 */
+export interface CourseXSemester {
+  id: string;
+  label: string;
+  current: boolean;
+}
+
+export async function getCourseXSemesters(fetchLike: FetchLike): Promise<CourseXSemester[]> {
+  const res = await fetchLike(`${SITE}/courses`, { headers: BROWSER_HEADERS });
+  if (!res.ok) throw new Error(`课程共享计划学期列表失败（HTTP ${res.status}）`);
+  const html = await res.text();
+  const select = /<select[^>]*id="semester-select"[\s\S]*?<\/select>/.exec(html)?.[0] ?? "";
+  const out: CourseXSemester[] = [];
+  const optRe = /<option value="([^"]+)"([^>]*)>([^<]*)<\/option>/g;
+  let m: RegExpExecArray | null;
+  while ((m = optRe.exec(select)) !== null) {
+    const id = m[1] ?? "";
+    const label = decodeEntities(m[3] ?? "");
+    if (id && label) out.push({ id, label, current: /selected/.test(m[2] ?? "") });
+  }
+  return out;
+}
+
+/** 免 Key 搜索：解析 /courses?q=（&s=学期，缺省=当前学期）服务端渲染结果表。
+ *  课程 id 形如 {学期id}-{课号课序}，semesterId 取前三段。 */
+export async function searchCourseXPublic(
+  fetchLike: FetchLike,
+  query: string,
+  semester?: string,
+): Promise<CourseXSummary[]> {
+  const s = semester ? `&s=${encodeURIComponent(semester)}` : "";
+  const res = await fetchLike(`${SITE}/courses?q=${encodeURIComponent(query)}${s}`, {
+    headers: BROWSER_HEADERS,
+  });
+  if (!res.ok) throw new Error(`课程共享计划搜索失败（HTTP ${res.status}）`);
+  const html = await res.text();
+  const out: CourseXSummary[] = [];
+  // 行形态：<tr><td>教师</td><td>课名<br/><span…>英文名</span></td><td>…href="/courses/{id}"
+  const rowRe =
+    /<tr><td>([\s\S]*?)<\/td><td>([\s\S]*?)<\/td><td[\s\S]*?href="\/courses\/([^"]+)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = rowRe.exec(html)) !== null) {
+    const id = m[3] ?? "";
+    const nameCell = m[2] ?? "";
+    const nameMatch = /^([\s\S]*?)(?:<br\/?>|$)/.exec(nameCell);
+    const name = decodeEntities(nameMatch?.[1] ?? nameCell);
+    if (!id || !name) continue;
+    const english = /<span[^>]*>([\s\S]*?)<\/span>/.exec(nameCell)?.[1];
+    out.push({
+      id,
+      name,
+      englishName: english ? decodeEntities(english) || undefined : undefined,
+      teacherName: decodeEntities(m[1] ?? ""),
+      semesterId: id.split("-").slice(0, 3).join("-"),
+    });
+  }
+  return out;
+}
+
+/** 免 Key 详情：解析 /courses/{id} 流内卡片（学期/课号课序/课名/英文名/教师/时间地点） */
+export async function getCourseXDetailPublic(
+  fetchLike: FetchLike,
+  id: string,
+): Promise<CourseXDetail | null> {
+  const res = await fetchLike(`${SITE}/courses/${encodeURIComponent(id)}`, {
+    headers: BROWSER_HEADERS,
+  });
+  if (!res.ok) throw new Error(`课程共享计划详情失败（HTTP ${res.status}）`);
+  const html = await res.text();
+  // 数据在流式渲染的隐藏块里：<div hidden id="S:N"><main …card…>…</main></div>
+  const card = /<div hidden id="S:\d+"><main[\s\S]*?<\/main>/.exec(html)?.[0]
+    ?? /<main[\s\S]*?card[\s\S]*?<\/main>/.exec(html)?.[0]
+    ?? "";
+  if (!card) return null;
+  const pick = (re: RegExp): string => decodeEntities(re.exec(card)?.[1] ?? "");
+  const ps = [...card.matchAll(/<p>([\s\S]*?)<\/p>/g)].map((x) => decodeEntities(x[1] ?? ""));
+  const lis = [...card.matchAll(/<li>([\s\S]*?)<\/li>/g)].map((x) => decodeEntities(x[1] ?? ""));
+  const name = pick(/<h1>([\s\S]*?)<\/h1>/);
+  if (!name) return null;
+  const teacherName = pick(/<h2>([\s\S]*?)<\/h2>/);
+  const englishName = pick(/<\/h1><p>([\s\S]*?)<\/p>/) || undefined;
+  return {
+    id,
+    name,
+    englishName,
+    teacherName,
+    semesterId: ps[0] ?? "",
+    timeLocation: lis,
+    reviewAvg: null,
+    reviewCount: 0,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -168,6 +168,26 @@ export type {
 export { LEARN_FILE_DOWNLOAD, LEARN_PREFIX } from "./learn/urls.js";
 export { setWebvpnLog } from "./auth/demoLogin.js";
 
+/* courseX 课程信息共享计划（tsinghua.app / 星期四，公开 GraphQL，众包时间地点） */
+export {
+  CourseXSession,
+  CourseXAuthError,
+  fetchCourseXAccessToken,
+  searchCourseX,
+  getCourseXDetail,
+  searchCourseXPublic,
+  getCourseXDetailPublic,
+  getCourseXSemesters,
+  uploadCoursesToCourseX,
+  courseXSemesterText,
+} from "./coursex/client.js";
+export type {
+  CourseXSummary,
+  CourseXDetail,
+  CourseXUploadCourse,
+  CourseXSemester,
+} from "./coursex/client.js";
+
 /* 体育场馆系统（sports.tsinghua.edu.cn unifound-venue）—— 独立 token 鉴权 */
 export { VenueClient, VenueAuthRequiredError, VenueApiError, VENUE_BASE, fmtVenueDate, venueTokenExpiresAt } from "./venue/client.js";
 export { md5hex, buildVenueSign, venueSignQuery, VENUE_APP_ID, VENUE_SIGN_KEY } from "./venue/sign.js";

--- a/packages/core/src/learn/client.ts
+++ b/packages/core/src/learn/client.ts
@@ -593,11 +593,40 @@ export class LearnClient {
           courseNumber: str(c.kch),
           courseIndex: Number(c.kxh ?? 0),
           teacherName: decodeHtml(c.jsm),
+          teacherNumber: str(c.jsh) || undefined,
           timeAndLocation: [],
           url: urls.LEARN_COURSE_PAGE(id),
         };
       });
     });
+  }
+
+  /** 课程时间地点（v_wlkc_xk_sjddb/detail，thu-learn-lib 同款：响应即 string[]；
+   *  单课失败容忍返回 []，调用方按无地点处理） */
+  async getCourseTimeAndLocation(courseId: string): Promise<string[]> {
+    return this.#withRelogin(async () => {
+      this.#requireCsrf();
+      const json = await this.#http.json<unknown>(
+        this.#withCsrf(urls.LEARN_COURSE_TIME_LOCATION(courseId)),
+      );
+      if (!Array.isArray(json)) return [];
+      return json.filter((s): s is string => typeof s === "string");
+    });
+  }
+
+  /** 课程共享计划专用：课程列表 + 并发补齐每门课的时间地点。
+   *  并发 4、单项失败容忍（该课 timeAndLocation 为 []），不改动 getCourseList 行为。 */
+  async getCourseListForSharing(semesterId: string): Promise<CourseInfo[]> {
+    const courses = await this.getCourseList(semesterId);
+    const out: CourseInfo[] = [];
+    for (let i = 0; i < courses.length; i += 4) {
+      const batch = courses.slice(i, i + 4);
+      const times = await Promise.all(
+        batch.map((c) => this.getCourseTimeAndLocation(c.id).catch(() => [] as string[])),
+      );
+      batch.forEach((c, j) => out.push({ ...c, timeAndLocation: times[j] ?? [] }));
+    }
+    return out;
   }
 
   /** 全部课程的作业（未交 + 已交未批 + 已批） */

--- a/packages/core/src/learn/types.ts
+++ b/packages/core/src/learn/types.ts
@@ -23,6 +23,8 @@ export interface CourseInfo {
   courseNumber: string;
   courseIndex: number;
   teacherName: string;
+  /** 教师号（jsh；列表接口不回传时为空，courseX 共享上传用） */
+  teacherNumber?: string;
   timeAndLocation: string[];
   url: string;
 }


### PR DESCRIPTION
Closes #17

## 概要

信息页新增「课程信息」栏目（个人信息之后），接入 [courseX](https://tsinghua.app/courses) 课程信息共享计划：按学期搜索全校任意开课，点行展开**上课时间与地点**。查询免凭证零配置；连接 courseX（可选）后可一键上传本学期课程回馈共享库。

## 交互（与 courseX 网页同款）

- 学期下拉（默认当前学期，2016 至今全部学期）+ 搜索框（课程名 / 教师名）
- 结果表：课程（含英文名）/ 教师 / 学期；点行展开时间地点条目（如「星期二第2节(全周)技术科学楼3311」）
- 切换学期已有搜索词时立即重查

## 实现

| 层 | 改动 |
|---|---|
| core | 新增 `coursex/client.ts`：公开查询（`searchCourseXPublic` / `getCourseXDetailPublic` / `getCourseXSemesters`，解析服务端渲染 HTML）+ GraphQL 会话与上传（learnX `insert_course` 同款，回馈可选） |
| core | learn 补 `getCourseTimeAndLocation`（sjddb，响应即 `string[]`）与 `getCourseListForSharing`（并发 4、单项失败容忍）；`getCourseList` 行为不变；`CourseInfo` 加 `teacherNumber`（jsh） |
| 桌面 | 新增 `pages/info/CourseInfoTab.tsx` 与 `lib/coursex.ts`（配置持久化 + 会话单例）；`InfoPage` 注册栏目（tabLayout 自动追加无需迁移）；`Settings` 新增「课程共享计划（可选）」区块 |

## 关键发现（踩坑记录）

1. **教务选课系统查不到地点**：kkxxSearch 全校目录无地点列；唯一数据源是 courseX 众包库（learnX 用户上传网络学堂 sjddb 时间地点）。
2. **网页查询免凭证**：tsinghua.app 为 Next.js 服务端渲染（RSC 流内含完整数据），匿名可解析；GraphQL 原始接口匿名零权限，仅上传回馈需要 token。
3. **自定义 UA 会被拦截**：`Mozilla/5.0 (OneTHU)` 实测返回空结果页（19 行 → 0 行），必须用标准浏览器 UA。
4. 课程 id 形如 `{学期id}-{课号课序}`，学期号取前三段。

## 验证

- [x] 解析器对真实页面验证：搜索「数学」19 行全对；详情含完整时间地点
- [x] `tsc -b` + `vite build` + `tauri build` 通过；已人工实测检视版（22:45 build）
- [ ] 上传回馈的普通用户 token insert 权限未实测（learnX 用打包服务账号）；被拒时诚实报错，后续可联系 courseX 作者协商正式集成
